### PR TITLE
Ignore tests in builds by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,15 +137,18 @@ target_link_libraries(aas_core3
         )
 
 # Testing
+OPTION(BUILD_TESTS "Build tests for aas-core-cpp" FALSE)
 
-include(CTest)
-enable_testing()
+if (${BUILD_TESTS})
+    include(CTest)
+    enable_testing()
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/test-external)
+    include_directories(${CMAKE_CURRENT_SOURCE_DIR}/test-external)
 
-add_executable(test_examples test/test_examples.cpp)
-target_link_libraries(test_examples aas_core3_static)
-add_test(NAME test_examples COMMAND test_examples)
+    add_executable(test_examples test/test_examples.cpp)
+    target_link_libraries(test_examples aas_core3_static)
+    add_test(NAME test_examples COMMAND test_examples)
+endif()
 
 # Set the version
 

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -23,6 +23,23 @@ However, this needs to be decided on a case-by-case basis.
 
 [aas-core-codegen]: https://github.com/aas-core-works/aas-core-codegen
 
+### Building Tests
+
+We introduce the CMake option `BUILD_TESTS`, so that the developer can decide whether the tests are built or not.
+Normal builds where the SDK is used as a dependency usually do not need to run tests, so `BUILD_TESTS` is set to `OFF` by default.
+
+If you want to build the tests, you have to specify the option when you invoke CMake.
+For example, assuming you want to build the project in `build/` directory, and you are in the root of the repository:
+
+```
+cmake \
+    -Bbuild/ \
+    -S. \
+    -DBUILD_TESTS=ON \
+    # ... and probably some more CMake lists options
+    $ dealing with the dependencies etc.
+```
+
 ## Pull Requests
 
 **Feature branches**.


### PR DESCRIPTION
Since most users build the project as the dependency, and not as the developers, we turn off the building of the tests by default.

We introduce the option `BUILD_TESTS` so that the developers can steer when the tests should be built.