### PR TITLE
Make verification functions for XSD types public

### DIFF
--- a/include/aas_core/aas_3_0/verification.hpp
+++ b/include/aas_core/aas_3_0/verification.hpp
@@ -240,13 +240,25 @@ bool MatchesXsDateTimeUtc(
   const std::wstring& text
 );
 
-/// \brief Check that \p text is a `xs:dateTime` with time zone set to UTC.
-///
-/// The `text` is assumed to match a pre-defined pattern for `xs:dateTime` with
-/// the time zone set to UTC. In this function, we check for days of month (e.g.,
-/// February 29th).
-///
-/// See: https://www.w3.org/TR/xmlschema-2/#dateTime
+/**
+ * \brief Check whether the given \p year is a leap year.
+ *
+ * Year 1 BCE is a leap year.
+ *
+ * \param year to be checked
+ * \return true if \p year is a leap year
+ */
+bool IsLeapYear(long long year);
+
+/**
+ *  \brief Check that \p text is a `xs:dateTime` with time zone set to UTC.
+ *
+ *  The `text` is assumed to match a pre-defined pattern for `xs:dateTime` with
+ *  the time zone set to UTC. In this function, we check for days of month (e.g.,
+ *  February 29th).
+ *
+ *  See: https://www.w3.org/TR/xmlschema-2/#dateTime
+ */
 bool IsXsDateTimeUtc(
   const std::wstring& text
 );
@@ -548,6 +560,94 @@ bool ValueConsistentWithXsdType(
   const std::wstring& value,
   types::DataTypeDefXsd value_type
 );
+
+/**
+ * \brief Check that \p value is a valid `xs:double`.
+ *
+ * \param value to be checked
+ * \return true if \p value is a valid `xs:double`
+ */
+bool IsXsDouble(const std::wstring& value);
+
+/**
+ * \brief Check that \p value is a valid `xs:float`.
+ *
+ * \param value to be checked
+ * \return true if \p value is a valid `xs:float`
+ */
+bool IsXsFloat(const std::wstring& value);
+
+/**
+ * \brief Check that \p value is a valid `xs:gMonthDay`.
+ *
+ * \param value to be checked
+ * \return true if \p value is a valid `xs:gMonthDay`
+ */
+bool IsXsGMonthDay(const std::wstring& value);
+
+/**
+ * \brief Check that \p value is a valid `xs:long`.
+ *
+ * \param value to be checked
+ * \return true if \p value is a valid `xs:long`
+ */
+bool IsXsLong(const std::wstring& value);
+
+/**
+ * \brief Check that \p value is a valid `xs:int`.
+ *
+ * \param value to be checked
+ * \return true if \p value is a valid `xs:int`
+ */
+bool IsXsInt(const std::wstring& value);
+
+/**
+ * \brief Check that \p value is a valid `xs:short`.
+ *
+ * \param value to be checked
+ * \return true if \p value is a valid `xs:short`
+ */
+bool IsXsShort(const std::wstring& value);
+
+/**
+ * \brief Check that \p value is a valid `xs:byte`.
+ *
+ * \param value to be checked
+ * \return true if \p value is a valid `xs:byte`
+ */
+bool IsXsByte(const std::wstring& value);
+
+/**
+ * \brief Check that \p value is a valid `xs:unsignedLong`.
+ *
+ * \param value to be checked
+ * \return true if \p value is a valid `xs:unsignedLong`
+ */
+bool IsXsUnsignedLong(const std::wstring& value);
+
+/**
+ * \brief Check that \p value is a valid `xs:unsignedInt`.
+ *
+ * \param value to be checked
+ * \return true if \p value is a valid `xs:unsignedInt`
+ */
+bool IsXsUnsignedInt(const std::wstring& value);
+
+/**
+ * \brief Check that \p value is a valid `xs:unsignedShort`.
+ *
+ * \param value to be checked
+ * \return true if \p value is a valid `xs:unsignedShort`
+ */
+bool IsXsUnsignedShort(const std::wstring& value);
+
+/**
+ * \brief Check that \p value is a valid `xs:unsignedByte`.
+ *
+ * \param value to be checked
+ * \return true if \p value is a valid `xs:unsignedByte`
+ */
+bool IsXsUnsignedByte(const std::wstring& value);
 
 /// \brief Check that the target of the model reference matches the \p expected_type.
 bool IsModelReferenceTo(

--- a/src/verification.cpp
+++ b/src/verification.cpp
@@ -223,14 +223,6 @@ const std::wregex kRegexDatePrefix(
   L"^(-?[0-9]+)-(0[1-9]|11|12)-(0[0-9]|1[0-9]|2[0-9]|30|31)"
 );
 
-/**
- * \brief Check whether the given \p year is a leap year.
- *
- * Year 1 BCE is a leap year.
- *
- * \param year to be checked
- * \return true if \p year is a leap year
- */
 bool IsLeapYear(long long year) {
   // NOTE (mristin):
   // We consider the years B.C. to be one-off.
@@ -2247,12 +2239,6 @@ bool MatchesXsString(
   );
 }
 
-/**
- * \brief Check that \p value is a valid `xs:double`.
- *
- * \param value to be checked
- * \return true if \p value is a valid `xs:double`
- */
 bool IsXsDouble(const std::wstring& value) {
   // NOTE (mristin):
   // We need to check explicitly for the regular expression since
@@ -2304,12 +2290,6 @@ bool IsXsDouble(const std::wstring& value) {
   return true;
 }
 
-/**
- * \brief Check that \p value is a valid `xs:float`.
- *
- * \param value to be checked
- * \return true if \p value is a valid `xs:float`
- */
 bool IsXsFloat(const std::wstring& value) {
   // NOTE (mristin):
   // We need to check explicitly for the regular expression since
@@ -2361,12 +2341,6 @@ bool IsXsFloat(const std::wstring& value) {
   return true;
 }
 
-/**
- * \brief Check that \p value is a valid `xs:gMonthDay`.
- *
- * \param value to be checked
- * \return true if \p value is a valid `xs:gMonthDay`
- */
 bool IsXsGMonthDay(const std::wstring& value) {
   if (!MatchesXsGMonthDay(value)) {
     return false;
@@ -2381,12 +2355,6 @@ bool IsXsGMonthDay(const std::wstring& value) {
   return day <= kDaysInMonth.at(month);
 }
 
-/**
- * \brief Check that \p value is a valid `xs:long`.
- *
- * \param value to be checked
- * \return true if \p value is a valid `xs:long`
- */
 bool IsXsLong(const std::wstring& value) {
   if (!MatchesXsLong(value)) {
     return false;
@@ -2432,12 +2400,6 @@ bool IsXsLong(const std::wstring& value) {
   return true;
 }
 
-/**
- * \brief Check that \p value is a valid `xs:int`.
- *
- * \param value to be checked
- * \return true if \p value is a valid `xs:int`
- */
 bool IsXsInt(const std::wstring& value) {
   if (!MatchesXsInt(value)) {
     return false;
@@ -2483,12 +2445,6 @@ bool IsXsInt(const std::wstring& value) {
   return true;
 }
 
-/**
- * \brief Check that \p value is a valid `xs:short`.
- *
- * \param value to be checked
- * \return true if \p value is a valid `xs:short`
- */
 bool IsXsShort(const std::wstring& value) {
   if (!MatchesXsShort(value)) {
     return false;
@@ -2513,12 +2469,6 @@ bool IsXsShort(const std::wstring& value) {
   return -32768 <= converted && converted <= 32767;
 }
 
-/**
- * \brief Check that \p value is a valid `xs:byte`.
- *
- * \param value to be checked
- * \return true if \p value is a valid `xs:byte`
- */
 bool IsXsByte(const std::wstring& value) {
   if (!MatchesXsByte(value)) {
     return false;
@@ -2543,12 +2493,6 @@ bool IsXsByte(const std::wstring& value) {
   return -128 <= converted && converted <= 127;
 }
 
-/**
- * \brief Check that \p value is a valid `xs:unsignedLong`.
- *
- * \param value to be checked
- * \return true if \p value is a valid `xs:unsignedLong`
- */
 bool IsXsUnsignedLong(const std::wstring& value) {
   if (!MatchesXsUnsignedLong(value)) {
     return false;
@@ -2559,8 +2503,8 @@ bool IsXsUnsignedLong(const std::wstring& value) {
     // We remove the warning C4101 in MSVC with constants.
     // See: https://stackoverflow.com/questions/25573996/c4127-conditional-expression-is-constant
 	const bool sizeof_unsigned_long_is_8 = sizeof(unsigned long) == 8;
-	const bool sizeof_unsigned_long_long_is_8 = sizeof(unsigned long long) == 8; 
-	 
+	const bool sizeof_unsigned_long_long_is_8 = sizeof(unsigned long long) == 8;
+
     if (sizeof_unsigned_long_is_8) {
       static_cast<void>(
         std::stoul(value)
@@ -2594,12 +2538,6 @@ bool IsXsUnsignedLong(const std::wstring& value) {
   return true;
 }
 
-/**
- * \brief Check that \p value is a valid `xs:unsignedInt`.
- *
- * \param value to be checked
- * \return true if \p value is a valid `xs:unsignedInt`
- */
 bool IsXsUnsignedInt(const std::wstring& value) {
   if (!MatchesXsUnsignedInt(value)) {
     return false;
@@ -2615,8 +2553,8 @@ bool IsXsUnsignedInt(const std::wstring& value) {
     // We remove the warning C4101 in MSVC with constants.
     // See: https://stackoverflow.com/questions/25573996/c4127-conditional-expression-is-constant
 	const bool sizeof_unsigned_long_ge_4 = sizeof(unsigned long) >= 4;
-	const bool sizeof_unsigned_long_long_ge_4 = sizeof(unsigned long long) >= 4;  
-  
+	const bool sizeof_unsigned_long_long_ge_4 = sizeof(unsigned long long) >= 4;
+
     if (sizeof_unsigned_long_ge_4) {
       const unsigned long number = std::stoul(value);
       return number <= 4294967295ul;
@@ -2648,12 +2586,6 @@ bool IsXsUnsignedInt(const std::wstring& value) {
   }
 }
 
-/**
- * \brief Check that \p value is a valid `xs:unsignedShort`.
- *
- * \param value to be checked
- * \return true if \p value is a valid `xs:unsignedShort`
- */
 bool IsXsUnsignedShort(const std::wstring& value) {
   if (!MatchesXsUnsignedShort(value)) {
     return false;
@@ -2673,8 +2605,8 @@ bool IsXsUnsignedShort(const std::wstring& value) {
     );
     const bool sizeof_unsigned_long_long_ge_4(
     	sizeof(unsigned long long) >= 4
-    ); 
-    
+    );
+
     if (sizeof_unsigned_long_ge_4) {
       const unsigned long number = std::stoul(value);
       return number <= 65535ul;
@@ -2706,12 +2638,6 @@ bool IsXsUnsignedShort(const std::wstring& value) {
   }
 }
 
-/**
- * \brief Check that \p value is a valid `xs:unsignedByte`.
- *
- * \param value to be checked
- * \return true if \p value is a valid `xs:unsignedByte`
- */
 bool IsXsUnsignedByte(const std::wstring& value) {
   if (!MatchesXsUnsignedByte(value)) {
     return false;


### PR DESCRIPTION
We make the verification functions for logical checks on XSD basic data types public, so that the clients can use them to determine errors in their AAS structures in a more fine-grained way.