### PR TITLE
Avoid global variables in tests

### DIFF
--- a/dev_scripts/test_codegen/generate_test_jsonization_of_concrete_classes.py
+++ b/dev_scripts/test_codegen/generate_test_jsonization_of_concrete_classes.py
@@ -156,17 +156,25 @@ void AssertDeserializationFailure(
         ),
         Stripped(
             f"""\
-const std::filesystem::path kJsonDir(
-{I}test::common::DetermineTestDataDir()
-{I}/ "Json"
-);"""
+const std::filesystem::path& DetermineJsonDir() {{
+{I}static aas::common::optional<std::filesystem::path> result;
+{I}if (!result.has_value()) {{
+{II}result = test::common::DetermineTestDataDir() / "Json";
+{I}}}
+
+{I}return *result;
+}}"""
         ),
         Stripped(
             f"""\
-const std::filesystem::path kErrorDir(
-{I}test::common::DetermineTestDataDir()
-{I}/ "JsonizationError"
-);"""
+const std::filesystem::path& DetermineErrorDir() {{
+{I}static aas::common::optional<std::filesystem::path> result;
+{I}if (!result.has_value()) {{
+{II}result = test::common::DetermineTestDataDir() / "JsonizationError";
+{I}}}
+
+{I}return *result;
+}}"""
         ),
     ]  # type: List[Stripped]
 
@@ -207,7 +215,7 @@ const std::filesystem::path kErrorDir(
 TEST_CASE("Test the round-trip of an expected {cls_name}") {{
 {I}const std::deque<std::filesystem::path> paths(
 {II}test::common::FindFilesBySuffixRecursively(
-{III}kJsonDir
+{III}DetermineJsonDir()
 {IIII}/ {cpp_common.string_literal(contained_in_dir_name)}
 {IIII}/ "Expected"
 {IIII}/ {cpp_common.string_literal(model_type)},
@@ -234,7 +242,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected {cls_name}") {{
 {I}) {{
 {II}const std::deque<std::filesystem::path> paths(
 {III}test::common::FindFilesBySuffixRecursively(
-{IIII}kJsonDir
+{IIII}DetermineJsonDir()
 {IIIII}/ {cpp_common.string_literal(contained_in_dir_name)}
 {IIIII}/ "Unexpected"
 {IIIII}/ cause
@@ -246,8 +254,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected {cls_name}") {{
 {II}for (const std::filesystem::path& path : paths) {{
 {III}const std::filesystem::path parent(
 {IIII}(
-{IIIII}kErrorDir
-{IIIII}/ std::filesystem::relative(path, kJsonDir)
+{IIIII}DetermineErrorDir()
+{IIIII}/ std::filesystem::relative(path, DetermineJsonDir())
 {IIII}).parent_path()
 {III});
 

--- a/dev_scripts/test_codegen/generate_test_xmlization_dispatch.py
+++ b/dev_scripts/test_codegen/generate_test_xmlization_dispatch.py
@@ -49,8 +49,6 @@ namespace aas = aas_core::aas_3_0;"""
         ),
     ]  # type: List[Stripped]
 
-    environment_cls = symbol_table.must_find_concrete_class(Identifier("Environment"))
-
     for cls in symbol_table.classes:
         if len(cls.concrete_descendants) == 0:
             continue
@@ -148,10 +146,7 @@ TEST_CASE("Test the round-trip of an expected {interface_name}") {{
 
     writer.write("\n")
 
-    target_pth = (
-        repo_root
-        / "test/test_xmlization_dispatch.generated.cpp"
-    )
+    target_pth = repo_root / "test/test_xmlization_dispatch.generated.cpp"
     target_pth.write_text(writer.getvalue(), encoding="utf-8")
 
     return 0

--- a/test/test_jsonization_of_concrete_classes.generated.cpp
+++ b/test/test_jsonization_of_concrete_classes.generated.cpp
@@ -112,20 +112,28 @@ void AssertDeserializationFailure(
   );
 }
 
-const std::filesystem::path kJsonDir(
-  test::common::DetermineTestDataDir()
-  / "Json"
-);
+const std::filesystem::path& DetermineJsonDir() {
+  static aas::common::optional<std::filesystem::path> result;
+  if (!result.has_value()) {
+    result = test::common::DetermineTestDataDir() / "Json";
+  }
 
-const std::filesystem::path kErrorDir(
-  test::common::DetermineTestDataDir()
-  / "JsonizationError"
-);
+  return *result;
+}
+
+const std::filesystem::path& DetermineErrorDir() {
+  static aas::common::optional<std::filesystem::path> result;
+  if (!result.has_value()) {
+    result = test::common::DetermineTestDataDir() / "JsonizationError";
+  }
+
+  return *result;
+}
 
 TEST_CASE("Test the round-trip of an expected Extension") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "Extension",
@@ -147,7 +155,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Extension") {
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -159,8 +167,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected Extension") {
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -183,7 +191,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Extension") {
 TEST_CASE("Test the round-trip of an expected AdministrativeInformation") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "AdministrativeInformation",
@@ -205,7 +213,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected AdministrativeInfo
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -217,8 +225,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected AdministrativeInfo
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -241,7 +249,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected AdministrativeInfo
 TEST_CASE("Test the round-trip of an expected Qualifier") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "Qualifier",
@@ -263,7 +271,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Qualifier") {
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -275,8 +283,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected Qualifier") {
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -299,7 +307,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Qualifier") {
 TEST_CASE("Test the round-trip of an expected AssetAdministrationShell") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "AssetAdministrationShell",
@@ -321,7 +329,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected AssetAdministratio
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -333,8 +341,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected AssetAdministratio
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -357,7 +365,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected AssetAdministratio
 TEST_CASE("Test the round-trip of an expected AssetInformation") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "AssetInformation",
@@ -379,7 +387,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected AssetInformation")
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -391,8 +399,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected AssetInformation")
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -415,7 +423,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected AssetInformation")
 TEST_CASE("Test the round-trip of an expected Resource") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "Resource",
@@ -437,7 +445,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Resource") {
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -449,8 +457,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected Resource") {
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -473,7 +481,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Resource") {
 TEST_CASE("Test the round-trip of an expected SpecificAssetId") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "SpecificAssetId",
@@ -495,7 +503,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected SpecificAssetId") 
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -507,8 +515,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected SpecificAssetId") 
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -531,7 +539,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected SpecificAssetId") 
 TEST_CASE("Test the round-trip of an expected Submodel") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "Submodel",
@@ -553,7 +561,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Submodel") {
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -565,8 +573,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected Submodel") {
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -589,7 +597,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Submodel") {
 TEST_CASE("Test the round-trip of an expected RelationshipElement") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "RelationshipElement",
@@ -611,7 +619,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected RelationshipElemen
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -623,8 +631,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected RelationshipElemen
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -647,7 +655,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected RelationshipElemen
 TEST_CASE("Test the round-trip of an expected SubmodelElementList") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "SubmodelElementList",
@@ -669,7 +677,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected SubmodelElementLis
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -681,8 +689,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected SubmodelElementLis
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -705,7 +713,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected SubmodelElementLis
 TEST_CASE("Test the round-trip of an expected SubmodelElementCollection") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "SubmodelElementCollection",
@@ -727,7 +735,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected SubmodelElementCol
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -739,8 +747,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected SubmodelElementCol
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -763,7 +771,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected SubmodelElementCol
 TEST_CASE("Test the round-trip of an expected Property") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "Property",
@@ -785,7 +793,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Property") {
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -797,8 +805,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected Property") {
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -821,7 +829,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Property") {
 TEST_CASE("Test the round-trip of an expected MultiLanguageProperty") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "MultiLanguageProperty",
@@ -843,7 +851,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected MultiLanguagePrope
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -855,8 +863,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected MultiLanguagePrope
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -879,7 +887,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected MultiLanguagePrope
 TEST_CASE("Test the round-trip of an expected Range") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "Range",
@@ -901,7 +909,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Range") {
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -913,8 +921,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected Range") {
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -937,7 +945,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Range") {
 TEST_CASE("Test the round-trip of an expected ReferenceElement") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "ReferenceElement",
@@ -959,7 +967,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected ReferenceElement")
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -971,8 +979,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected ReferenceElement")
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -995,7 +1003,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected ReferenceElement")
 TEST_CASE("Test the round-trip of an expected Blob") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "Blob",
@@ -1017,7 +1025,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Blob") {
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -1029,8 +1037,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected Blob") {
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -1053,7 +1061,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Blob") {
 TEST_CASE("Test the round-trip of an expected File") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "File",
@@ -1075,7 +1083,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected File") {
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -1087,8 +1095,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected File") {
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -1111,7 +1119,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected File") {
 TEST_CASE("Test the round-trip of an expected AnnotatedRelationshipElement") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "AnnotatedRelationshipElement",
@@ -1133,7 +1141,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected AnnotatedRelations
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -1145,8 +1153,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected AnnotatedRelations
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -1169,7 +1177,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected AnnotatedRelations
 TEST_CASE("Test the round-trip of an expected Entity") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "Entity",
@@ -1191,7 +1199,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Entity") {
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -1203,8 +1211,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected Entity") {
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -1227,7 +1235,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Entity") {
 TEST_CASE("Test the round-trip of an expected EventPayload") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "SelfContained"
         / "Expected"
         / "EventPayload",
@@ -1249,7 +1257,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected EventPayload") {
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "SelfContained"
           / "Unexpected"
           / cause
@@ -1261,8 +1269,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected EventPayload") {
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -1285,7 +1293,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected EventPayload") {
 TEST_CASE("Test the round-trip of an expected BasicEventElement") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "BasicEventElement",
@@ -1307,7 +1315,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected BasicEventElement"
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -1319,8 +1327,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected BasicEventElement"
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -1343,7 +1351,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected BasicEventElement"
 TEST_CASE("Test the round-trip of an expected Operation") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "Operation",
@@ -1365,7 +1373,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Operation") {
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -1377,8 +1385,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected Operation") {
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -1401,7 +1409,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Operation") {
 TEST_CASE("Test the round-trip of an expected OperationVariable") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "OperationVariable",
@@ -1423,7 +1431,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected OperationVariable"
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -1435,8 +1443,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected OperationVariable"
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -1459,7 +1467,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected OperationVariable"
 TEST_CASE("Test the round-trip of an expected Capability") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "Capability",
@@ -1481,7 +1489,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Capability") {
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -1493,8 +1501,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected Capability") {
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -1517,7 +1525,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Capability") {
 TEST_CASE("Test the round-trip of an expected ConceptDescription") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "ConceptDescription",
@@ -1539,7 +1547,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected ConceptDescription
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -1551,8 +1559,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected ConceptDescription
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -1575,7 +1583,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected ConceptDescription
 TEST_CASE("Test the round-trip of an expected Reference") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "Reference",
@@ -1597,7 +1605,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Reference") {
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -1609,8 +1617,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected Reference") {
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -1633,7 +1641,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Reference") {
 TEST_CASE("Test the round-trip of an expected Key") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "Key",
@@ -1655,7 +1663,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Key") {
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -1667,8 +1675,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected Key") {
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -1691,7 +1699,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Key") {
 TEST_CASE("Test the round-trip of an expected LangStringNameType") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "LangStringNameType",
@@ -1713,7 +1721,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected LangStringNameType
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -1725,8 +1733,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected LangStringNameType
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -1749,7 +1757,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected LangStringNameType
 TEST_CASE("Test the round-trip of an expected LangStringTextType") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "LangStringTextType",
@@ -1771,7 +1779,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected LangStringTextType
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -1783,8 +1791,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected LangStringTextType
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -1807,7 +1815,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected LangStringTextType
 TEST_CASE("Test the round-trip of an expected Environment") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "SelfContained"
         / "Expected"
         / "Environment",
@@ -1829,7 +1837,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Environment") {
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "SelfContained"
           / "Unexpected"
           / cause
@@ -1841,8 +1849,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected Environment") {
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -1865,7 +1873,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Environment") {
 TEST_CASE("Test the round-trip of an expected EmbeddedDataSpecification") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "EmbeddedDataSpecification",
@@ -1887,7 +1895,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected EmbeddedDataSpecif
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -1899,8 +1907,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected EmbeddedDataSpecif
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -1923,7 +1931,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected EmbeddedDataSpecif
 TEST_CASE("Test the round-trip of an expected LevelType") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "LevelType",
@@ -1945,7 +1953,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected LevelType") {
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -1957,8 +1965,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected LevelType") {
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -1981,7 +1989,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected LevelType") {
 TEST_CASE("Test the round-trip of an expected ValueReferencePair") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "ValueReferencePair",
@@ -2003,7 +2011,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected ValueReferencePair
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -2015,8 +2023,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected ValueReferencePair
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -2039,7 +2047,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected ValueReferencePair
 TEST_CASE("Test the round-trip of an expected ValueList") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "ValueList",
@@ -2061,7 +2069,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected ValueList") {
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -2073,8 +2081,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected ValueList") {
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -2097,7 +2105,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected ValueList") {
 TEST_CASE("Test the round-trip of an expected LangStringPreferredNameTypeIec61360") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "LangStringPreferredNameTypeIec61360",
@@ -2119,7 +2127,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected LangStringPreferre
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -2131,8 +2139,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected LangStringPreferre
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -2155,7 +2163,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected LangStringPreferre
 TEST_CASE("Test the round-trip of an expected LangStringShortNameTypeIec61360") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "LangStringShortNameTypeIec61360",
@@ -2177,7 +2185,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected LangStringShortNam
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -2189,8 +2197,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected LangStringShortNam
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -2213,7 +2221,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected LangStringShortNam
 TEST_CASE("Test the round-trip of an expected LangStringDefinitionTypeIec61360") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "LangStringDefinitionTypeIec61360",
@@ -2235,7 +2243,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected LangStringDefiniti
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -2247,8 +2255,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected LangStringDefiniti
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 
@@ -2271,7 +2279,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected LangStringDefiniti
 TEST_CASE("Test the round-trip of an expected DataSpecificationIec61360") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kJsonDir
+      DetermineJsonDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "DataSpecificationIec61360",
@@ -2293,7 +2301,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected DataSpecificationI
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kJsonDir
+        DetermineJsonDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -2305,8 +2313,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected DataSpecificationI
     for (const std::filesystem::path& path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kJsonDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineJsonDir())
         ).parent_path()
       );
 

--- a/test/test_xmlization_of_concrete_classes.generated.cpp
+++ b/test/test_xmlization_of_concrete_classes.generated.cpp
@@ -102,20 +102,28 @@ void AssertDeserializationFailure(
   );
 }
 
-const std::filesystem::path kXmlDir(
-  test::common::DetermineTestDataDir()
-  / "Xml"
-);
+const std::filesystem::path& DetermineXmlDir() {
+  static aas::common::optional<std::filesystem::path> result;
+  if (!result.has_value()) {
+    result = test::common::DetermineTestDataDir() / "Xml";
+  }
 
-const std::filesystem::path kErrorDir(
-  test::common::DetermineTestDataDir()
-  / "XmlizationError"
-);
+  return *result;
+}
+
+const std::filesystem::path& DetermineErrorDir() {
+  static aas::common::optional<std::filesystem::path> result;
+  if (!result.has_value()) {
+    result = test::common::DetermineTestDataDir() / "XmlizationError";
+  }
+
+  return *result;
+}
 
 TEST_CASE("Test the round-trip of an expected Extension") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "extension",
@@ -135,7 +143,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Extension") {
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -147,8 +155,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected Extension") {
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -168,7 +176,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Extension") {
 TEST_CASE("Test the round-trip of an expected AdministrativeInformation") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "administrativeInformation",
@@ -188,7 +196,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected AdministrativeInfo
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -200,8 +208,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected AdministrativeInfo
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -221,7 +229,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected AdministrativeInfo
 TEST_CASE("Test the round-trip of an expected Qualifier") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "qualifier",
@@ -241,7 +249,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Qualifier") {
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -253,8 +261,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected Qualifier") {
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -274,7 +282,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Qualifier") {
 TEST_CASE("Test the round-trip of an expected AssetAdministrationShell") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "assetAdministrationShell",
@@ -294,7 +302,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected AssetAdministratio
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -306,8 +314,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected AssetAdministratio
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -327,7 +335,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected AssetAdministratio
 TEST_CASE("Test the round-trip of an expected AssetInformation") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "assetInformation",
@@ -347,7 +355,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected AssetInformation")
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -359,8 +367,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected AssetInformation")
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -380,7 +388,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected AssetInformation")
 TEST_CASE("Test the round-trip of an expected Resource") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "resource",
@@ -400,7 +408,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Resource") {
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -412,8 +420,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected Resource") {
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -433,7 +441,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Resource") {
 TEST_CASE("Test the round-trip of an expected SpecificAssetId") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "specificAssetId",
@@ -453,7 +461,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected SpecificAssetId") 
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -465,8 +473,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected SpecificAssetId") 
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -486,7 +494,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected SpecificAssetId") 
 TEST_CASE("Test the round-trip of an expected Submodel") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "submodel",
@@ -506,7 +514,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Submodel") {
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -518,8 +526,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected Submodel") {
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -539,7 +547,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Submodel") {
 TEST_CASE("Test the round-trip of an expected RelationshipElement") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "relationshipElement",
@@ -559,7 +567,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected RelationshipElemen
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -571,8 +579,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected RelationshipElemen
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -592,7 +600,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected RelationshipElemen
 TEST_CASE("Test the round-trip of an expected SubmodelElementList") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "submodelElementList",
@@ -612,7 +620,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected SubmodelElementLis
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -624,8 +632,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected SubmodelElementLis
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -645,7 +653,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected SubmodelElementLis
 TEST_CASE("Test the round-trip of an expected SubmodelElementCollection") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "submodelElementCollection",
@@ -665,7 +673,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected SubmodelElementCol
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -677,8 +685,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected SubmodelElementCol
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -698,7 +706,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected SubmodelElementCol
 TEST_CASE("Test the round-trip of an expected Property") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "property",
@@ -718,7 +726,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Property") {
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -730,8 +738,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected Property") {
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -751,7 +759,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Property") {
 TEST_CASE("Test the round-trip of an expected MultiLanguageProperty") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "multiLanguageProperty",
@@ -771,7 +779,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected MultiLanguagePrope
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -783,8 +791,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected MultiLanguagePrope
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -804,7 +812,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected MultiLanguagePrope
 TEST_CASE("Test the round-trip of an expected Range") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "range",
@@ -824,7 +832,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Range") {
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -836,8 +844,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected Range") {
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -857,7 +865,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Range") {
 TEST_CASE("Test the round-trip of an expected ReferenceElement") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "referenceElement",
@@ -877,7 +885,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected ReferenceElement")
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -889,8 +897,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected ReferenceElement")
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -910,7 +918,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected ReferenceElement")
 TEST_CASE("Test the round-trip of an expected Blob") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "blob",
@@ -930,7 +938,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Blob") {
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -942,8 +950,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected Blob") {
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -963,7 +971,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Blob") {
 TEST_CASE("Test the round-trip of an expected File") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "file",
@@ -983,7 +991,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected File") {
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -995,8 +1003,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected File") {
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -1016,7 +1024,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected File") {
 TEST_CASE("Test the round-trip of an expected AnnotatedRelationshipElement") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "annotatedRelationshipElement",
@@ -1036,7 +1044,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected AnnotatedRelations
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -1048,8 +1056,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected AnnotatedRelations
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -1069,7 +1077,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected AnnotatedRelations
 TEST_CASE("Test the round-trip of an expected Entity") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "entity",
@@ -1089,7 +1097,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Entity") {
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -1101,8 +1109,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected Entity") {
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -1122,7 +1130,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Entity") {
 TEST_CASE("Test the round-trip of an expected EventPayload") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "SelfContained"
         / "Expected"
         / "eventPayload",
@@ -1142,7 +1150,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected EventPayload") {
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "SelfContained"
           / "Unexpected"
           / cause
@@ -1154,8 +1162,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected EventPayload") {
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -1175,7 +1183,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected EventPayload") {
 TEST_CASE("Test the round-trip of an expected BasicEventElement") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "basicEventElement",
@@ -1195,7 +1203,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected BasicEventElement"
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -1207,8 +1215,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected BasicEventElement"
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -1228,7 +1236,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected BasicEventElement"
 TEST_CASE("Test the round-trip of an expected Operation") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "operation",
@@ -1248,7 +1256,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Operation") {
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -1260,8 +1268,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected Operation") {
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -1281,7 +1289,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Operation") {
 TEST_CASE("Test the round-trip of an expected OperationVariable") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "operationVariable",
@@ -1301,7 +1309,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected OperationVariable"
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -1313,8 +1321,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected OperationVariable"
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -1334,7 +1342,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected OperationVariable"
 TEST_CASE("Test the round-trip of an expected Capability") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "capability",
@@ -1354,7 +1362,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Capability") {
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -1366,8 +1374,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected Capability") {
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -1387,7 +1395,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Capability") {
 TEST_CASE("Test the round-trip of an expected ConceptDescription") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "conceptDescription",
@@ -1407,7 +1415,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected ConceptDescription
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -1419,8 +1427,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected ConceptDescription
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -1440,7 +1448,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected ConceptDescription
 TEST_CASE("Test the round-trip of an expected Reference") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "reference",
@@ -1460,7 +1468,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Reference") {
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -1472,8 +1480,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected Reference") {
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -1493,7 +1501,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Reference") {
 TEST_CASE("Test the round-trip of an expected Key") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "key",
@@ -1513,7 +1521,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Key") {
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -1525,8 +1533,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected Key") {
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -1546,7 +1554,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Key") {
 TEST_CASE("Test the round-trip of an expected LangStringNameType") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "langStringNameType",
@@ -1566,7 +1574,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected LangStringNameType
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -1578,8 +1586,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected LangStringNameType
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -1599,7 +1607,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected LangStringNameType
 TEST_CASE("Test the round-trip of an expected LangStringTextType") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "langStringTextType",
@@ -1619,7 +1627,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected LangStringTextType
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -1631,8 +1639,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected LangStringTextType
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -1652,7 +1660,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected LangStringTextType
 TEST_CASE("Test the round-trip of an expected Environment") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "SelfContained"
         / "Expected"
         / "environment",
@@ -1672,7 +1680,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Environment") {
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "SelfContained"
           / "Unexpected"
           / cause
@@ -1684,8 +1692,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected Environment") {
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -1705,7 +1713,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected Environment") {
 TEST_CASE("Test the round-trip of an expected EmbeddedDataSpecification") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "embeddedDataSpecification",
@@ -1725,7 +1733,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected EmbeddedDataSpecif
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -1737,8 +1745,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected EmbeddedDataSpecif
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -1758,7 +1766,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected EmbeddedDataSpecif
 TEST_CASE("Test the round-trip of an expected LevelType") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "levelType",
@@ -1778,7 +1786,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected LevelType") {
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -1790,8 +1798,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected LevelType") {
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -1811,7 +1819,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected LevelType") {
 TEST_CASE("Test the round-trip of an expected ValueReferencePair") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "valueReferencePair",
@@ -1831,7 +1839,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected ValueReferencePair
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -1843,8 +1851,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected ValueReferencePair
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -1864,7 +1872,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected ValueReferencePair
 TEST_CASE("Test the round-trip of an expected ValueList") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "valueList",
@@ -1884,7 +1892,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected ValueList") {
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -1896,8 +1904,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected ValueList") {
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -1917,7 +1925,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected ValueList") {
 TEST_CASE("Test the round-trip of an expected LangStringPreferredNameTypeIec61360") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "langStringPreferredNameTypeIec61360",
@@ -1937,7 +1945,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected LangStringPreferre
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -1949,8 +1957,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected LangStringPreferre
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -1970,7 +1978,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected LangStringPreferre
 TEST_CASE("Test the round-trip of an expected LangStringShortNameTypeIec61360") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "langStringShortNameTypeIec61360",
@@ -1990,7 +1998,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected LangStringShortNam
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -2002,8 +2010,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected LangStringShortNam
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -2023,7 +2031,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected LangStringShortNam
 TEST_CASE("Test the round-trip of an expected LangStringDefinitionTypeIec61360") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "langStringDefinitionTypeIec61360",
@@ -2043,7 +2051,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected LangStringDefiniti
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -2055,8 +2063,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected LangStringDefiniti
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 
@@ -2076,7 +2084,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected LangStringDefiniti
 TEST_CASE("Test the round-trip of an expected DataSpecificationIec61360") {
   const std::deque<std::filesystem::path> paths(
     test::common::FindFilesBySuffixRecursively(
-      kXmlDir
+      DetermineXmlDir()
         / "ContainedInEnvironment"
         / "Expected"
         / "dataSpecificationIec61360",
@@ -2096,7 +2104,7 @@ TEST_CASE("Test the de-serialization failure on an unexpected DataSpecificationI
   ) {
     const std::deque<std::filesystem::path> paths(
       test::common::FindFilesBySuffixRecursively(
-        kXmlDir
+        DetermineXmlDir()
           / "ContainedInEnvironment"
           / "Unexpected"
           / cause
@@ -2108,8 +2116,8 @@ TEST_CASE("Test the de-serialization failure on an unexpected DataSpecificationI
     for (const std::filesystem::path &path : paths) {
       const std::filesystem::path parent(
         (
-          kErrorDir
-          / std::filesystem::relative(path, kXmlDir)
+          DetermineErrorDir()
+          / std::filesystem::relative(path, DetermineXmlDir())
         ).parent_path()
       );
 


### PR DESCRIPTION
We should not use global variables in tests whose construction might throw an exception, as the program immediately exits and no error message is written to the user.

For example, if the environment variable pointing to the test data is not set, the global variable specifying a subdirectory in the test data would simply cause an exception, but the user is oblivious what caused the problem.