### PR TITLE
Fix update script so that it builds

### DIFF
--- a/src/BigInt.hpp
+++ b/src/BigInt.hpp
@@ -1147,7 +1147,7 @@ BigInt BigInt::operator+(const BigInt& num) const {
     result.value = "";  // the value is cleared as the digits will be appended
     short carry = 0, sum;
     // add the two values
-    for (long i = larger.size() - 1; i >= 0; i--) {
+    for (size_t i = larger.size() - 1; i >= 0; i--) {
         sum = larger[i] - '0' + smaller[i] - '0' + carry;
         result.value = std::to_string(sum % 10) + result.value;
         carry = sum / (short) 10;
@@ -1206,7 +1206,7 @@ BigInt BigInt::operator-(const BigInt& num) const {
     short difference;
     long i, j;
     // subtract the two values
-    for (i = larger.size() - 1; i >= 0; i--) {
+    for (i = static_cast<long>(larger.size()) - 1; i >= 0; i--) {
         difference = larger[i] - smaller[i];
         if (difference < 0) {
             for (j = i - 1; j >= 0; j--) {

--- a/test/common_xmlization.cpp
+++ b/test/common_xmlization.cpp
@@ -532,7 +532,7 @@ std::string CanonicalizeXml(
   XML_Status status = XML_Parse(
     parser,
     xml.data(),
-    xml.size(),
+    static_cast<int>(xml.size()),
     true
   );
 


### PR DESCRIPTION
The update script had to be adapted as well as the BigInt library so that MSVC now builds everything. Additionally, we also have to fix common XML-ization module in tests.

Previously, a couple of issues in BigInt and common XML-ization prevented the compilation. Namely, we compared signed and unsigned values. The update script was too sparse on messages and we could not figure out what went wrong.