### PR TITLE
Update to aas-core-meta, codegen, testgen 79314c6, e90f027, dce96d10

### DIFF
--- a/dev_scripts/aas_core3/__init__.py
+++ b/dev_scripts/aas_core3/__init__.py
@@ -3,5 +3,5 @@ Provide Python SDK as copied from aas-core-codegen test data.
 
 This copy is necessary so that we can decouple from ``aas-core*-python`` repository.
 
-The revision of aas-core-codegen was: a206fe8
+The revision of aas-core-codegen was: e90f027
 """

--- a/dev_scripts/setup.py
+++ b/dev_scripts/setup.py
@@ -30,7 +30,7 @@ setup(
     install_requires=[
         "icontract>=2.6.1,<3",
         "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@79314c6#egg=aas-core-meta",
-        "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@a206fe8#egg=aas-core-codegen",
+        "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@e90f027#egg=aas-core-codegen",
     ],
     # fmt: off
     extras_require={


### PR DESCRIPTION
We update the development requirements to and re-generate everything with:
* [aas-core-meta 79314c6],
* [aas-core-codegen e90f027] and
* [aas-core3.0-testgen dce96d10].

We notably propagate the fix to the positive example of `xs:double` in testgen.

[aas-core-meta 79314c6]: https://github.com/aas-core-works/aas-core-meta/commit/79314c6
[aas-core-codegen e90f027]: https://github.com/aas-core-works/aas-core-codegen/commit/e90f027
[aas-core3.0-testgen dce96d10]: https://github.com/aas-core-works/aas-core3.0-testgen/commit/dce96d10