### PR TITLE
Update to aas-core-meta, codegen, testgen 79314c6, e90f027, d4bafa4c

### DIFF
--- a/dev_scripts/aas_core3/__init__.py
+++ b/dev_scripts/aas_core3/__init__.py
@@ -3,5 +3,5 @@ Provide Python SDK as copied from aas-core-codegen test data.
 
 This copy is necessary so that we can decouple from ``aas-core*-python`` repository.
 
-The revision of aas-core-codegen was: a206fe8
+The revision of aas-core-codegen was: e90f027
 """

--- a/dev_scripts/setup.py
+++ b/dev_scripts/setup.py
@@ -30,7 +30,7 @@ setup(
     install_requires=[
         "icontract>=2.6.1,<3",
         "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@79314c6#egg=aas-core-meta",
-        "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@a206fe8#egg=aas-core-codegen",
+        "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@e90f027#egg=aas-core-codegen",
     ],
     # fmt: off
     extras_require={

--- a/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Double/fuzzed_06.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Double/fuzzed_06.json
@@ -8,7 +8,7 @@
       "extensions": [
         {
           "name": "something_aae6caf4",
-          "value": "+7626E-86876716",
+          "value": "+76E-86",
           "valueType": "xs:double"
         }
       ],

--- a/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Double/fuzzed_06.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Double/fuzzed_06.json
@@ -7,7 +7,7 @@
         {
           "idShort": "something3fdd3eb4",
           "modelType": "Property",
-          "value": "+7626E-86876716",
+          "value": "+76E-86",
           "valueType": "xs:double"
         }
       ]

--- a/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Double/fuzzed_06.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Double/fuzzed_06.json
@@ -6,7 +6,7 @@
       "qualifiers": [
         {
           "type": "something_5964ab43",
-          "value": "+7626E-86876716",
+          "value": "+76E-86",
           "valueType": "xs:double"
         }
       ]

--- a/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Double/fuzzed_06.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Double/fuzzed_06.json
@@ -6,8 +6,8 @@
       "submodelElements": [
         {
           "idShort": "something3fdd3eb4",
-          "max": "+7626E-86876716",
-          "min": "+7626E-86876716",
+          "max": "+76E-86",
+          "min": "+76E-86",
           "modelType": "Range",
           "valueType": "xs:double"
         }

--- a/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Double/fuzzed_06.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Double/fuzzed_06.xml
@@ -5,7 +5,7 @@
 				<extension>
 					<name>something_aae6caf4</name>
 					<valueType>xs:double</valueType>
-					<value>+7626E-86876716</value>
+					<value>+76E-86</value>
 				</extension>
 			</extensions>
 			<id>something_142922d6</id>

--- a/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Double/fuzzed_06.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Double/fuzzed_06.xml
@@ -6,7 +6,7 @@
 				<property>
 					<idShort>something3fdd3eb4</idShort>
 					<valueType>xs:double</valueType>
-					<value>+7626E-86876716</value>
+					<value>+76E-86</value>
 				</property>
 			</submodelElements>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Double/fuzzed_06.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Double/fuzzed_06.xml
@@ -6,7 +6,7 @@
 				<qualifier>
 					<type>something_5964ab43</type>
 					<valueType>xs:double</valueType>
-					<value>+7626E-86876716</value>
+					<value>+76E-86</value>
 				</qualifier>
 			</qualifiers>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Double/fuzzed_06.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Double/fuzzed_06.xml
@@ -6,8 +6,8 @@
 				<range>
 					<idShort>something3fdd3eb4</idShort>
 					<valueType>xs:double</valueType>
-					<min>+7626E-86876716</min>
-					<max>+7626E-86876716</max>
+					<min>+76E-86</min>
+					<max>+76E-86</max>
 				</range>
 			</submodelElements>
 		</submodel>


### PR DESCRIPTION
We update the development requirements to and re-generate everything with:
* [aas-core-meta 79314c6],
* [aas-core-codegen e90f027] and
* [aas-core3.0-testgen d4bafa4c].

Notably, we propagate the change in testgen related to incorrect positive example of an `xs:double`.

[aas-core-meta 79314c6]: https://github.com/aas-core-works/aas-core-meta/commit/79314c6
[aas-core-codegen e90f027]: https://github.com/aas-core-works/aas-core-codegen/commit/e90f027
[aas-core3.0-testgen d4bafa4c]: https://github.com/aas-core-works/aas-core3.0-testgen/commit/d4bafa4c