### PR TITLE
Fix `set_target_properties` in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,8 +103,9 @@ SET(SRC
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 add_library(aas_core3_static STATIC ${HEADER} ${SRC})
-set_target_properties(aas_core3_static PROPERTIES
-        PUBLIC_HEADER ${HEADER}
+set_target_properties(aas_core3_static
+        PROPERTIES
+        PUBLIC_HEADER "${HEADER}"
         )
 # NOTE (mristin):
 # We need to distinguish between BUILD and INSTALL interface,
@@ -133,8 +134,9 @@ target_include_directories(aas_core3
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>
         )
-set_target_properties(aas_core3 PROPERTIES
-        PUBLIC_HEADER ${HEADER}
+set_target_properties(aas_core3
+        PROPERTIES
+        PUBLIC_HEADER "${HEADER}"
         )
 target_link_libraries(aas_core3
         PRIVATE


### PR DESCRIPTION
We mistakenly forgot to stringify the multiple header paths in the calls to `set_target_properties` in `CMake`.

This went unnoticed when all the paths existed, but failed if one of the header paths was missing.

This patch fixes the issue.