### PR TITLE
Update to aas-core3.0-testgen ac2febcde

### DIFF
--- a/test_data/Descent/ContainedInEnvironment/Expected/langStringDefinitionTypeIec61360/languageOverPatternExamples/fuzzed_01.xml.trace
+++ b/test_data/Descent/ContainedInEnvironment/Expected/langStringDefinitionTypeIec61360/languageOverPatternExamples/fuzzed_01.xml.trace
@@ -1,9 +1,0 @@
-AssetAdministrationShell with ID something_142922d6
-EmbeddedDataSpecification
-Reference
-Key
-DataSpecificationIec61360
-LangStringPreferredNameTypeIec61360
-LangStringPreferredNameTypeIec61360
-LangStringDefinitionTypeIec61360
-AssetInformation

--- a/test_data/Descent/ContainedInEnvironment/Expected/langStringDefinitionTypeIec61360/languageOverPatternExamples/fuzzed_02.xml.trace
+++ b/test_data/Descent/ContainedInEnvironment/Expected/langStringDefinitionTypeIec61360/languageOverPatternExamples/fuzzed_02.xml.trace
@@ -1,9 +1,0 @@
-AssetAdministrationShell with ID something_142922d6
-EmbeddedDataSpecification
-Reference
-Key
-DataSpecificationIec61360
-LangStringPreferredNameTypeIec61360
-LangStringPreferredNameTypeIec61360
-LangStringDefinitionTypeIec61360
-AssetInformation

--- a/test_data/Descent/ContainedInEnvironment/Expected/langStringDefinitionTypeIec61360/languageOverPatternExamples/fuzzed_03.xml.trace
+++ b/test_data/Descent/ContainedInEnvironment/Expected/langStringDefinitionTypeIec61360/languageOverPatternExamples/fuzzed_03.xml.trace
@@ -1,9 +1,0 @@
-AssetAdministrationShell with ID something_142922d6
-EmbeddedDataSpecification
-Reference
-Key
-DataSpecificationIec61360
-LangStringPreferredNameTypeIec61360
-LangStringPreferredNameTypeIec61360
-LangStringDefinitionTypeIec61360
-AssetInformation

--- a/test_data/Descent/ContainedInEnvironment/Expected/langStringDefinitionTypeIec61360/languageOverPatternExamples/language_and_dialect.xml.trace
+++ b/test_data/Descent/ContainedInEnvironment/Expected/langStringDefinitionTypeIec61360/languageOverPatternExamples/language_and_dialect.xml.trace
@@ -1,9 +1,0 @@
-AssetAdministrationShell with ID something_142922d6
-EmbeddedDataSpecification
-Reference
-Key
-DataSpecificationIec61360
-LangStringPreferredNameTypeIec61360
-LangStringPreferredNameTypeIec61360
-LangStringDefinitionTypeIec61360
-AssetInformation

--- a/test_data/Descent/ContainedInEnvironment/Expected/langStringDefinitionTypeIec61360/languageOverPatternExamples/only_language.xml.trace
+++ b/test_data/Descent/ContainedInEnvironment/Expected/langStringDefinitionTypeIec61360/languageOverPatternExamples/only_language.xml.trace
@@ -1,9 +1,0 @@
-AssetAdministrationShell with ID something_142922d6
-EmbeddedDataSpecification
-Reference
-Key
-DataSpecificationIec61360
-LangStringPreferredNameTypeIec61360
-LangStringPreferredNameTypeIec61360
-LangStringDefinitionTypeIec61360
-AssetInformation

--- a/test_data/Descent/ContainedInEnvironment/Expected/langStringNameType/languageOverPatternExamples/fuzzed_01.xml.trace
+++ b/test_data/Descent/ContainedInEnvironment/Expected/langStringNameType/languageOverPatternExamples/fuzzed_01.xml.trace
@@ -1,3 +1,0 @@
-AssetAdministrationShell with ID something_142922d6
-LangStringNameType
-AssetInformation

--- a/test_data/Descent/ContainedInEnvironment/Expected/langStringNameType/languageOverPatternExamples/fuzzed_02.xml.trace
+++ b/test_data/Descent/ContainedInEnvironment/Expected/langStringNameType/languageOverPatternExamples/fuzzed_02.xml.trace
@@ -1,3 +1,0 @@
-AssetAdministrationShell with ID something_142922d6
-LangStringNameType
-AssetInformation

--- a/test_data/Descent/ContainedInEnvironment/Expected/langStringNameType/languageOverPatternExamples/fuzzed_03.xml.trace
+++ b/test_data/Descent/ContainedInEnvironment/Expected/langStringNameType/languageOverPatternExamples/fuzzed_03.xml.trace
@@ -1,3 +1,0 @@
-AssetAdministrationShell with ID something_142922d6
-LangStringNameType
-AssetInformation

--- a/test_data/Descent/ContainedInEnvironment/Expected/langStringNameType/languageOverPatternExamples/language_and_dialect.xml.trace
+++ b/test_data/Descent/ContainedInEnvironment/Expected/langStringNameType/languageOverPatternExamples/language_and_dialect.xml.trace
@@ -1,3 +1,0 @@
-AssetAdministrationShell with ID something_142922d6
-LangStringNameType
-AssetInformation

--- a/test_data/Descent/ContainedInEnvironment/Expected/langStringNameType/languageOverPatternExamples/only_language.xml.trace
+++ b/test_data/Descent/ContainedInEnvironment/Expected/langStringNameType/languageOverPatternExamples/only_language.xml.trace
@@ -1,3 +1,0 @@
-AssetAdministrationShell with ID something_142922d6
-LangStringNameType
-AssetInformation

--- a/test_data/Descent/ContainedInEnvironment/Expected/langStringPreferredNameTypeIec61360/languageOverPatternExamples/fuzzed_01.xml.trace
+++ b/test_data/Descent/ContainedInEnvironment/Expected/langStringPreferredNameTypeIec61360/languageOverPatternExamples/fuzzed_01.xml.trace
@@ -1,8 +1,0 @@
-AssetAdministrationShell with ID something_142922d6
-EmbeddedDataSpecification
-Reference
-Key
-DataSpecificationIec61360
-LangStringPreferredNameTypeIec61360
-LangStringPreferredNameTypeIec61360
-AssetInformation

--- a/test_data/Descent/ContainedInEnvironment/Expected/langStringPreferredNameTypeIec61360/languageOverPatternExamples/fuzzed_02.xml.trace
+++ b/test_data/Descent/ContainedInEnvironment/Expected/langStringPreferredNameTypeIec61360/languageOverPatternExamples/fuzzed_02.xml.trace
@@ -1,8 +1,0 @@
-AssetAdministrationShell with ID something_142922d6
-EmbeddedDataSpecification
-Reference
-Key
-DataSpecificationIec61360
-LangStringPreferredNameTypeIec61360
-LangStringPreferredNameTypeIec61360
-AssetInformation

--- a/test_data/Descent/ContainedInEnvironment/Expected/langStringPreferredNameTypeIec61360/languageOverPatternExamples/fuzzed_03.xml.trace
+++ b/test_data/Descent/ContainedInEnvironment/Expected/langStringPreferredNameTypeIec61360/languageOverPatternExamples/fuzzed_03.xml.trace
@@ -1,8 +1,0 @@
-AssetAdministrationShell with ID something_142922d6
-EmbeddedDataSpecification
-Reference
-Key
-DataSpecificationIec61360
-LangStringPreferredNameTypeIec61360
-LangStringPreferredNameTypeIec61360
-AssetInformation

--- a/test_data/Descent/ContainedInEnvironment/Expected/langStringPreferredNameTypeIec61360/languageOverPatternExamples/language_and_dialect.xml.trace
+++ b/test_data/Descent/ContainedInEnvironment/Expected/langStringPreferredNameTypeIec61360/languageOverPatternExamples/language_and_dialect.xml.trace
@@ -1,8 +1,0 @@
-AssetAdministrationShell with ID something_142922d6
-EmbeddedDataSpecification
-Reference
-Key
-DataSpecificationIec61360
-LangStringPreferredNameTypeIec61360
-LangStringPreferredNameTypeIec61360
-AssetInformation

--- a/test_data/Descent/ContainedInEnvironment/Expected/langStringPreferredNameTypeIec61360/languageOverPatternExamples/only_language.xml.trace
+++ b/test_data/Descent/ContainedInEnvironment/Expected/langStringPreferredNameTypeIec61360/languageOverPatternExamples/only_language.xml.trace
@@ -1,8 +1,0 @@
-AssetAdministrationShell with ID something_142922d6
-EmbeddedDataSpecification
-Reference
-Key
-DataSpecificationIec61360
-LangStringPreferredNameTypeIec61360
-LangStringPreferredNameTypeIec61360
-AssetInformation

--- a/test_data/Descent/ContainedInEnvironment/Expected/langStringShortNameTypeIec61360/languageOverPatternExamples/fuzzed_01.xml.trace
+++ b/test_data/Descent/ContainedInEnvironment/Expected/langStringShortNameTypeIec61360/languageOverPatternExamples/fuzzed_01.xml.trace
@@ -1,9 +1,0 @@
-AssetAdministrationShell with ID something_142922d6
-EmbeddedDataSpecification
-Reference
-Key
-DataSpecificationIec61360
-LangStringPreferredNameTypeIec61360
-LangStringPreferredNameTypeIec61360
-LangStringShortNameTypeIec61360
-AssetInformation

--- a/test_data/Descent/ContainedInEnvironment/Expected/langStringShortNameTypeIec61360/languageOverPatternExamples/fuzzed_02.xml.trace
+++ b/test_data/Descent/ContainedInEnvironment/Expected/langStringShortNameTypeIec61360/languageOverPatternExamples/fuzzed_02.xml.trace
@@ -1,9 +1,0 @@
-AssetAdministrationShell with ID something_142922d6
-EmbeddedDataSpecification
-Reference
-Key
-DataSpecificationIec61360
-LangStringPreferredNameTypeIec61360
-LangStringPreferredNameTypeIec61360
-LangStringShortNameTypeIec61360
-AssetInformation

--- a/test_data/Descent/ContainedInEnvironment/Expected/langStringShortNameTypeIec61360/languageOverPatternExamples/fuzzed_03.xml.trace
+++ b/test_data/Descent/ContainedInEnvironment/Expected/langStringShortNameTypeIec61360/languageOverPatternExamples/fuzzed_03.xml.trace
@@ -1,9 +1,0 @@
-AssetAdministrationShell with ID something_142922d6
-EmbeddedDataSpecification
-Reference
-Key
-DataSpecificationIec61360
-LangStringPreferredNameTypeIec61360
-LangStringPreferredNameTypeIec61360
-LangStringShortNameTypeIec61360
-AssetInformation

--- a/test_data/Descent/ContainedInEnvironment/Expected/langStringShortNameTypeIec61360/languageOverPatternExamples/language_and_dialect.xml.trace
+++ b/test_data/Descent/ContainedInEnvironment/Expected/langStringShortNameTypeIec61360/languageOverPatternExamples/language_and_dialect.xml.trace
@@ -1,9 +1,0 @@
-AssetAdministrationShell with ID something_142922d6
-EmbeddedDataSpecification
-Reference
-Key
-DataSpecificationIec61360
-LangStringPreferredNameTypeIec61360
-LangStringPreferredNameTypeIec61360
-LangStringShortNameTypeIec61360
-AssetInformation

--- a/test_data/Descent/ContainedInEnvironment/Expected/langStringShortNameTypeIec61360/languageOverPatternExamples/only_language.xml.trace
+++ b/test_data/Descent/ContainedInEnvironment/Expected/langStringShortNameTypeIec61360/languageOverPatternExamples/only_language.xml.trace
@@ -1,9 +1,0 @@
-AssetAdministrationShell with ID something_142922d6
-EmbeddedDataSpecification
-Reference
-Key
-DataSpecificationIec61360
-LangStringPreferredNameTypeIec61360
-LangStringPreferredNameTypeIec61360
-LangStringShortNameTypeIec61360
-AssetInformation

--- a/test_data/Descent/ContainedInEnvironment/Expected/langStringTextType/languageOverPatternExamples/fuzzed_01.xml.trace
+++ b/test_data/Descent/ContainedInEnvironment/Expected/langStringTextType/languageOverPatternExamples/fuzzed_01.xml.trace
@@ -1,3 +1,0 @@
-AssetAdministrationShell with ID something_142922d6
-LangStringTextType
-AssetInformation

--- a/test_data/Descent/ContainedInEnvironment/Expected/langStringTextType/languageOverPatternExamples/fuzzed_02.xml.trace
+++ b/test_data/Descent/ContainedInEnvironment/Expected/langStringTextType/languageOverPatternExamples/fuzzed_02.xml.trace
@@ -1,3 +1,0 @@
-AssetAdministrationShell with ID something_142922d6
-LangStringTextType
-AssetInformation

--- a/test_data/Descent/ContainedInEnvironment/Expected/langStringTextType/languageOverPatternExamples/fuzzed_03.xml.trace
+++ b/test_data/Descent/ContainedInEnvironment/Expected/langStringTextType/languageOverPatternExamples/fuzzed_03.xml.trace
@@ -1,3 +1,0 @@
-AssetAdministrationShell with ID something_142922d6
-LangStringTextType
-AssetInformation

--- a/test_data/Descent/ContainedInEnvironment/Expected/langStringTextType/languageOverPatternExamples/language_and_dialect.xml.trace
+++ b/test_data/Descent/ContainedInEnvironment/Expected/langStringTextType/languageOverPatternExamples/language_and_dialect.xml.trace
@@ -1,3 +1,0 @@
-AssetAdministrationShell with ID something_142922d6
-LangStringTextType
-AssetInformation

--- a/test_data/Descent/ContainedInEnvironment/Expected/langStringTextType/languageOverPatternExamples/only_language.xml.trace
+++ b/test_data/Descent/ContainedInEnvironment/Expected/langStringTextType/languageOverPatternExamples/only_language.xml.trace
@@ -1,3 +1,0 @@
-AssetAdministrationShell with ID something_142922d6
-LangStringTextType
-AssetInformation

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/NullViolation/EmbeddedDataSpecification/dataSpecification.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/NullViolation/EmbeddedDataSpecification/dataSpecification.json.error
@@ -1,1 +1,0 @@
-.assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecification: Expected an object, but got: null

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/RequiredViolation/EmbeddedDataSpecification/dataSpecification.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/RequiredViolation/EmbeddedDataSpecification/dataSpecification.json.error
@@ -1,1 +1,0 @@
-.assetAdministrationShells[0].embeddedDataSpecifications[0]: The required property dataSpecification is missing

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/TypeViolation/AdministrativeInformation/creator.json
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/TypeViolation/AdministrativeInformation/creator.json
@@ -1,1 +1,0 @@
-.assetAdministrationShells[0].administration.creator: Expected an object, but got: string

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/TypeViolation/AdministrativeInformation/embeddedDataSpecifications.json
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/TypeViolation/AdministrativeInformation/embeddedDataSpecifications.json
@@ -1,1 +1,0 @@
-.assetAdministrationShells[0].administration.embeddedDataSpecifications: Expected an array, but got: string

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/TypeViolation/AdministrativeInformation/revision.json
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/TypeViolation/AdministrativeInformation/revision.json
@@ -1,1 +1,0 @@
-.assetAdministrationShells[0].administration.revision: Expected a string, but got a value of type: array

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/TypeViolation/AdministrativeInformation/templateId.json
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/TypeViolation/AdministrativeInformation/templateId.json
@@ -1,1 +1,0 @@
-.assetAdministrationShells[0].administration.templateId: Expected a string, but got a value of type: array

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/TypeViolation/AdministrativeInformation/version.json
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/TypeViolation/AdministrativeInformation/version.json
@@ -1,1 +1,0 @@
-.assetAdministrationShells[0].administration.version: Expected a string, but got a value of type: array

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/AdministrativeInformation/invalid.json
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/UnexpectedAdditionalProperty/AdministrativeInformation/invalid.json
@@ -1,1 +1,0 @@
-.assetAdministrationShells[0].administration: Unexpected additional property: unexpectedAdditionalProperty

--- a/test_data/XmlizationError/ContainedInEnvironment/Unexpected/RequiredViolation/embeddedDataSpecification/dataSpecification.xml.error
+++ b/test_data/XmlizationError/ContainedInEnvironment/Unexpected/RequiredViolation/embeddedDataSpecification/dataSpecification.xml.error
@@ -1,1 +1,0 @@
-environment/assetAdministrationShells/*[0]/assetAdministrationShell/embeddedDataSpecifications/*[0]/embeddedDataSpecification: The required property dataSpecification is missing


### PR DESCRIPTION
We re-record the test data for the testing examples from [aas-core3.0-testgen ac2febcde]. Some of the recorded test files are deleted as the cases were removed from aas-core3.0-testgen in a series of bug fixes.

[aas-core3.0-testgen ac2febcde]: https://github.com/aas-core-works/aas-core3.0-testgen/commit/ac2febcde