### PR TITLE
Check explicitly for invalid model types

### DIFF
--- a/include/aas_core/aas_3_0/revm.hpp
+++ b/include/aas_core/aas_3_0/revm.hpp
@@ -30,7 +30,7 @@ namespace aas_3_0 {
  * https://swtch.com/~rsc/regexp/regexp2.html
  *
  * The ideas for additional instructions were taken from:
- * https://www.codeproject.com/Articles/5256833/Regex-as-a-Tiny-Threaded-Virtual-Machine  
+ * https://www.codeproject.com/Articles/5256833/Regex-as-a-Tiny-Threaded-Virtual-Machine
  * @{
  */
 namespace revm {
@@ -58,7 +58,7 @@ struct Instruction {
 };
 
 /**
- * Match a single character. 
+ * Match a single character.
  *
  * If the character on the String Pointer does not match the `character`, stop this
  * thread as it failed. Otherwise, move the String Pointer to the next character,

--- a/src/jsonization.cpp
+++ b/src/jsonization.cpp
@@ -3849,6 +3849,18 @@ std::pair<
     );
   }
 
+  if (!json.contains("modelType")) {
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      common::make_optional<DeserializationError>(
+        L"The required property modelType is missing"
+      )
+    );
+  }
+
   // endregion Check required properties
 
   // region Initialization
@@ -4528,6 +4540,58 @@ std::pair<
   }
 
   // endregion De-serialize submodels
+
+  // region Check model type
+  // This check is intended only for verification, not for dispatch.
+
+  common::optional<
+    std::wstring
+  > model_type;
+
+  std::tie(
+    model_type,
+    error
+  ) = DeserializeWstring(
+    json["modelType"]
+  );
+
+  if (error.has_value()) {
+    error->path.segments.emplace_front(
+      common::make_unique<PropertySegment>(
+        L"modelType"
+      )
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  if (*model_type != L"AssetAdministrationShell") {
+    std::wstring message = common::Concat(
+      L"Expected model type 'AssetAdministrationShell', "
+      L"but got: ",
+      *model_type
+    );
+
+    error = common::make_optional<DeserializationError>(
+      message
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  // endregion Check model type
 
   return std::make_pair(
     common::make_optional<
@@ -5480,6 +5544,18 @@ std::pair<
     );
   }
 
+  if (!json.contains("modelType")) {
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      common::make_optional<DeserializationError>(
+        L"The required property modelType is missing"
+      )
+    );
+  }
+
   // endregion Check required properties
 
   // region Initialization
@@ -6384,6 +6460,58 @@ std::pair<
 
   // endregion De-serialize submodelElements
 
+  // region Check model type
+  // This check is intended only for verification, not for dispatch.
+
+  common::optional<
+    std::wstring
+  > model_type;
+
+  std::tie(
+    model_type,
+    error
+  ) = DeserializeWstring(
+    json["modelType"]
+  );
+
+  if (error.has_value()) {
+    error->path.segments.emplace_front(
+      common::make_unique<PropertySegment>(
+        L"modelType"
+      )
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  if (*model_type != L"Submodel") {
+    std::wstring message = common::Concat(
+      L"Expected model type 'Submodel', "
+      L"but got: ",
+      *model_type
+    );
+
+    error = common::make_optional<DeserializationError>(
+      message
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  // endregion Check model type
+
   return std::make_pair(
     common::make_optional<
       std::shared_ptr<T>
@@ -6647,6 +6775,18 @@ std::pair<
       common::nullopt,
       common::make_optional<DeserializationError>(
         L"The required property second is missing"
+      )
+    );
+  }
+
+  if (!json.contains("modelType")) {
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      common::make_optional<DeserializationError>(
+        L"The required property modelType is missing"
       )
     );
   }
@@ -7393,6 +7533,58 @@ std::pair<
 
   // endregion De-serialize second
 
+  // region Check model type
+  // This check is intended only for verification, not for dispatch.
+
+  common::optional<
+    std::wstring
+  > model_type;
+
+  std::tie(
+    model_type,
+    error
+  ) = DeserializeWstring(
+    json["modelType"]
+  );
+
+  if (error.has_value()) {
+    error->path.segments.emplace_front(
+      common::make_unique<PropertySegment>(
+        L"modelType"
+      )
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  if (*model_type != L"RelationshipElement") {
+    std::wstring message = common::Concat(
+      L"Expected model type 'RelationshipElement', "
+      L"but got: ",
+      *model_type
+    );
+
+    error = common::make_optional<DeserializationError>(
+      message
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  // endregion Check model type
+
   return std::make_pair(
     common::make_optional<
       std::shared_ptr<T>
@@ -7573,6 +7765,18 @@ std::pair<
       common::nullopt,
       common::make_optional<DeserializationError>(
         L"The required property typeValueListElement is missing"
+      )
+    );
+  }
+
+  if (!json.contains("modelType")) {
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      common::make_optional<DeserializationError>(
+        L"The required property modelType is missing"
       )
     );
   }
@@ -8541,6 +8745,58 @@ std::pair<
 
   // endregion De-serialize value
 
+  // region Check model type
+  // This check is intended only for verification, not for dispatch.
+
+  common::optional<
+    std::wstring
+  > model_type;
+
+  std::tie(
+    model_type,
+    error
+  ) = DeserializeWstring(
+    json["modelType"]
+  );
+
+  if (error.has_value()) {
+    error->path.segments.emplace_front(
+      common::make_unique<PropertySegment>(
+        L"modelType"
+      )
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  if (*model_type != L"SubmodelElementList") {
+    std::wstring message = common::Concat(
+      L"Expected model type 'SubmodelElementList', "
+      L"but got: ",
+      *model_type
+    );
+
+    error = common::make_optional<DeserializationError>(
+      message
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  // endregion Check model type
+
   return std::make_pair(
     common::make_optional<
       std::shared_ptr<T>
@@ -8636,6 +8892,22 @@ std::pair<
       }
     }
   }
+
+  // region Check required properties
+
+  if (!json.contains("modelType")) {
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      common::make_optional<DeserializationError>(
+        L"The required property modelType is missing"
+      )
+    );
+  }
+
+  // endregion Check required properties
 
   // region Initialization
 
@@ -9412,6 +9684,58 @@ std::pair<
 
   // endregion De-serialize value
 
+  // region Check model type
+  // This check is intended only for verification, not for dispatch.
+
+  common::optional<
+    std::wstring
+  > model_type;
+
+  std::tie(
+    model_type,
+    error
+  ) = DeserializeWstring(
+    json["modelType"]
+  );
+
+  if (error.has_value()) {
+    error->path.segments.emplace_front(
+      common::make_unique<PropertySegment>(
+        L"modelType"
+      )
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  if (*model_type != L"SubmodelElementCollection") {
+    std::wstring message = common::Concat(
+      L"Expected model type 'SubmodelElementCollection', "
+      L"but got: ",
+      *model_type
+    );
+
+    error = common::make_optional<DeserializationError>(
+      message
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  // endregion Check model type
+
   return std::make_pair(
     common::make_optional<
       std::shared_ptr<T>
@@ -9613,6 +9937,18 @@ std::pair<
       common::nullopt,
       common::make_optional<DeserializationError>(
         L"The required property valueType is missing"
+      )
+    );
+  }
+
+  if (!json.contains("modelType")) {
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      common::make_optional<DeserializationError>(
+        L"The required property modelType is missing"
       )
     );
   }
@@ -10424,6 +10760,58 @@ std::pair<
 
   // endregion De-serialize valueId
 
+  // region Check model type
+  // This check is intended only for verification, not for dispatch.
+
+  common::optional<
+    std::wstring
+  > model_type;
+
+  std::tie(
+    model_type,
+    error
+  ) = DeserializeWstring(
+    json["modelType"]
+  );
+
+  if (error.has_value()) {
+    error->path.segments.emplace_front(
+      common::make_unique<PropertySegment>(
+        L"modelType"
+      )
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  if (*model_type != L"Property") {
+    std::wstring message = common::Concat(
+      L"Expected model type 'Property', "
+      L"but got: ",
+      *model_type
+    );
+
+    error = common::make_optional<DeserializationError>(
+      message
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  // endregion Check model type
+
   return std::make_pair(
     common::make_optional<
       std::shared_ptr<T>
@@ -10518,6 +10906,22 @@ std::pair<
       }
     }
   }
+
+  // region Check required properties
+
+  if (!json.contains("modelType")) {
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      common::make_optional<DeserializationError>(
+        L"The required property modelType is missing"
+      )
+    );
+  }
+
+  // endregion Check required properties
 
   // region Initialization
 
@@ -11330,6 +11734,58 @@ std::pair<
 
   // endregion De-serialize valueId
 
+  // region Check model type
+  // This check is intended only for verification, not for dispatch.
+
+  common::optional<
+    std::wstring
+  > model_type;
+
+  std::tie(
+    model_type,
+    error
+  ) = DeserializeWstring(
+    json["modelType"]
+  );
+
+  if (error.has_value()) {
+    error->path.segments.emplace_front(
+      common::make_unique<PropertySegment>(
+        L"modelType"
+      )
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  if (*model_type != L"MultiLanguageProperty") {
+    std::wstring message = common::Concat(
+      L"Expected model type 'MultiLanguageProperty', "
+      L"but got: ",
+      *model_type
+    );
+
+    error = common::make_optional<DeserializationError>(
+      message
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  // endregion Check model type
+
   return std::make_pair(
     common::make_optional<
       std::shared_ptr<T>
@@ -11435,6 +11891,18 @@ std::pair<
       common::nullopt,
       common::make_optional<DeserializationError>(
         L"The required property valueType is missing"
+      )
+    );
+  }
+
+  if (!json.contains("modelType")) {
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      common::make_optional<DeserializationError>(
+        L"The required property modelType is missing"
       )
     );
   }
@@ -12243,6 +12711,58 @@ std::pair<
 
   // endregion De-serialize max
 
+  // region Check model type
+  // This check is intended only for verification, not for dispatch.
+
+  common::optional<
+    std::wstring
+  > model_type;
+
+  std::tie(
+    model_type,
+    error
+  ) = DeserializeWstring(
+    json["modelType"]
+  );
+
+  if (error.has_value()) {
+    error->path.segments.emplace_front(
+      common::make_unique<PropertySegment>(
+        L"modelType"
+      )
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  if (*model_type != L"Range") {
+    std::wstring message = common::Concat(
+      L"Expected model type 'Range', "
+      L"but got: ",
+      *model_type
+    );
+
+    error = common::make_optional<DeserializationError>(
+      message
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  // endregion Check model type
+
   return std::make_pair(
     common::make_optional<
       std::shared_ptr<T>
@@ -12336,6 +12856,22 @@ std::pair<
       }
     }
   }
+
+  // region Check required properties
+
+  if (!json.contains("modelType")) {
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      common::make_optional<DeserializationError>(
+        L"The required property modelType is missing"
+      )
+    );
+  }
+
+  // endregion Check required properties
 
   // region Initialization
 
@@ -13051,6 +13587,58 @@ std::pair<
 
   // endregion De-serialize value
 
+  // region Check model type
+  // This check is intended only for verification, not for dispatch.
+
+  common::optional<
+    std::wstring
+  > model_type;
+
+  std::tie(
+    model_type,
+    error
+  ) = DeserializeWstring(
+    json["modelType"]
+  );
+
+  if (error.has_value()) {
+    error->path.segments.emplace_front(
+      common::make_unique<PropertySegment>(
+        L"modelType"
+      )
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  if (*model_type != L"ReferenceElement") {
+    std::wstring message = common::Concat(
+      L"Expected model type 'ReferenceElement', "
+      L"but got: ",
+      *model_type
+    );
+
+    error = common::make_optional<DeserializationError>(
+      message
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  // endregion Check model type
+
   return std::make_pair(
     common::make_optional<
       std::shared_ptr<T>
@@ -13154,6 +13742,18 @@ std::pair<
       common::nullopt,
       common::make_optional<DeserializationError>(
         L"The required property contentType is missing"
+      )
+    );
+  }
+
+  if (!json.contains("modelType")) {
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      common::make_optional<DeserializationError>(
+        L"The required property modelType is missing"
       )
     );
   }
@@ -13902,6 +14502,58 @@ std::pair<
 
   // endregion De-serialize contentType
 
+  // region Check model type
+  // This check is intended only for verification, not for dispatch.
+
+  common::optional<
+    std::wstring
+  > model_type;
+
+  std::tie(
+    model_type,
+    error
+  ) = DeserializeWstring(
+    json["modelType"]
+  );
+
+  if (error.has_value()) {
+    error->path.segments.emplace_front(
+      common::make_unique<PropertySegment>(
+        L"modelType"
+      )
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  if (*model_type != L"Blob") {
+    std::wstring message = common::Concat(
+      L"Expected model type 'Blob', "
+      L"but got: ",
+      *model_type
+    );
+
+    error = common::make_optional<DeserializationError>(
+      message
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  // endregion Check model type
+
   return std::make_pair(
     common::make_optional<
       std::shared_ptr<T>
@@ -14006,6 +14658,18 @@ std::pair<
       common::nullopt,
       common::make_optional<DeserializationError>(
         L"The required property contentType is missing"
+      )
+    );
+  }
+
+  if (!json.contains("modelType")) {
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      common::make_optional<DeserializationError>(
+        L"The required property modelType is missing"
       )
     );
   }
@@ -14752,6 +15416,58 @@ std::pair<
 
   // endregion De-serialize contentType
 
+  // region Check model type
+  // This check is intended only for verification, not for dispatch.
+
+  common::optional<
+    std::wstring
+  > model_type;
+
+  std::tie(
+    model_type,
+    error
+  ) = DeserializeWstring(
+    json["modelType"]
+  );
+
+  if (error.has_value()) {
+    error->path.segments.emplace_front(
+      common::make_unique<PropertySegment>(
+        L"modelType"
+      )
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  if (*model_type != L"File") {
+    std::wstring message = common::Concat(
+      L"Expected model type 'File', "
+      L"but got: ",
+      *model_type
+    );
+
+    error = common::make_optional<DeserializationError>(
+      message
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  // endregion Check model type
+
   return std::make_pair(
     common::make_optional<
       std::shared_ptr<T>
@@ -14869,6 +15585,18 @@ std::pair<
       common::nullopt,
       common::make_optional<DeserializationError>(
         L"The required property second is missing"
+      )
+    );
+  }
+
+  if (!json.contains("modelType")) {
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      common::make_optional<DeserializationError>(
+        L"The required property modelType is missing"
       )
     );
   }
@@ -15710,6 +16438,58 @@ std::pair<
 
   // endregion De-serialize annotations
 
+  // region Check model type
+  // This check is intended only for verification, not for dispatch.
+
+  common::optional<
+    std::wstring
+  > model_type;
+
+  std::tie(
+    model_type,
+    error
+  ) = DeserializeWstring(
+    json["modelType"]
+  );
+
+  if (error.has_value()) {
+    error->path.segments.emplace_front(
+      common::make_unique<PropertySegment>(
+        L"modelType"
+      )
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  if (*model_type != L"AnnotatedRelationshipElement") {
+    std::wstring message = common::Concat(
+      L"Expected model type 'AnnotatedRelationshipElement', "
+      L"but got: ",
+      *model_type
+    );
+
+    error = common::make_optional<DeserializationError>(
+      message
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  // endregion Check model type
+
   return std::make_pair(
     common::make_optional<
       std::shared_ptr<T>
@@ -15817,6 +16597,18 @@ std::pair<
       common::nullopt,
       common::make_optional<DeserializationError>(
         L"The required property entityType is missing"
+      )
+    );
+  }
+
+  if (!json.contains("modelType")) {
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      common::make_optional<DeserializationError>(
+        L"The required property modelType is missing"
       )
     );
   }
@@ -16786,6 +17578,58 @@ std::pair<
 
   // endregion De-serialize specificAssetIds
 
+  // region Check model type
+  // This check is intended only for verification, not for dispatch.
+
+  common::optional<
+    std::wstring
+  > model_type;
+
+  std::tie(
+    model_type,
+    error
+  ) = DeserializeWstring(
+    json["modelType"]
+  );
+
+  if (error.has_value()) {
+    error->path.segments.emplace_front(
+      common::make_unique<PropertySegment>(
+        L"modelType"
+      )
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  if (*model_type != L"Entity") {
+    std::wstring message = common::Concat(
+      L"Expected model type 'Entity', "
+      L"but got: ",
+      *model_type
+    );
+
+    error = common::make_optional<DeserializationError>(
+      message
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  // endregion Check model type
+
   return std::make_pair(
     common::make_optional<
       std::shared_ptr<T>
@@ -17373,6 +18217,18 @@ std::pair<
       common::nullopt,
       common::make_optional<DeserializationError>(
         L"The required property state is missing"
+      )
+    );
+  }
+
+  if (!json.contains("modelType")) {
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      common::make_optional<DeserializationError>(
+        L"The required property modelType is missing"
       )
     );
   }
@@ -18367,6 +19223,58 @@ std::pair<
 
   // endregion De-serialize maxInterval
 
+  // region Check model type
+  // This check is intended only for verification, not for dispatch.
+
+  common::optional<
+    std::wstring
+  > model_type;
+
+  std::tie(
+    model_type,
+    error
+  ) = DeserializeWstring(
+    json["modelType"]
+  );
+
+  if (error.has_value()) {
+    error->path.segments.emplace_front(
+      common::make_unique<PropertySegment>(
+        L"modelType"
+      )
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  if (*model_type != L"BasicEventElement") {
+    std::wstring message = common::Concat(
+      L"Expected model type 'BasicEventElement', "
+      L"but got: ",
+      *model_type
+    );
+
+    error = common::make_optional<DeserializationError>(
+      message
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  // endregion Check model type
+
   return std::make_pair(
     common::make_optional<
       std::shared_ptr<T>
@@ -18467,6 +19375,22 @@ std::pair<
       }
     }
   }
+
+  // region Check required properties
+
+  if (!json.contains("modelType")) {
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      common::make_optional<DeserializationError>(
+        L"The required property modelType is missing"
+      )
+    );
+  }
+
+  // endregion Check required properties
 
   // region Initialization
 
@@ -19433,6 +20357,58 @@ std::pair<
 
   // endregion De-serialize inoutputVariables
 
+  // region Check model type
+  // This check is intended only for verification, not for dispatch.
+
+  common::optional<
+    std::wstring
+  > model_type;
+
+  std::tie(
+    model_type,
+    error
+  ) = DeserializeWstring(
+    json["modelType"]
+  );
+
+  if (error.has_value()) {
+    error->path.segments.emplace_front(
+      common::make_unique<PropertySegment>(
+        L"modelType"
+      )
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  if (*model_type != L"Operation") {
+    std::wstring message = common::Concat(
+      L"Expected model type 'Operation', "
+      L"but got: ",
+      *model_type
+    );
+
+    error = common::make_optional<DeserializationError>(
+      message
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  // endregion Check model type
+
   return std::make_pair(
     common::make_optional<
       std::shared_ptr<T>
@@ -19646,6 +20622,22 @@ std::pair<
       }
     }
   }
+
+  // region Check required properties
+
+  if (!json.contains("modelType")) {
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      common::make_optional<DeserializationError>(
+        L"The required property modelType is missing"
+      )
+    );
+  }
+
+  // endregion Check required properties
 
   // region Initialization
 
@@ -20327,6 +21319,58 @@ std::pair<
 
   // endregion De-serialize embeddedDataSpecifications
 
+  // region Check model type
+  // This check is intended only for verification, not for dispatch.
+
+  common::optional<
+    std::wstring
+  > model_type;
+
+  std::tie(
+    model_type,
+    error
+  ) = DeserializeWstring(
+    json["modelType"]
+  );
+
+  if (error.has_value()) {
+    error->path.segments.emplace_front(
+      common::make_unique<PropertySegment>(
+        L"modelType"
+      )
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  if (*model_type != L"Capability") {
+    std::wstring message = common::Concat(
+      L"Expected model type 'Capability', "
+      L"but got: ",
+      *model_type
+    );
+
+    error = common::make_optional<DeserializationError>(
+      message
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  // endregion Check model type
+
   return std::make_pair(
     common::make_optional<
       std::shared_ptr<T>
@@ -20427,6 +21471,18 @@ std::pair<
       common::nullopt,
       common::make_optional<DeserializationError>(
         L"The required property id is missing"
+      )
+    );
+  }
+
+  if (!json.contains("modelType")) {
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      common::make_optional<DeserializationError>(
+        L"The required property modelType is missing"
       )
     );
   }
@@ -21046,6 +22102,58 @@ std::pair<
   }
 
   // endregion De-serialize isCaseOf
+
+  // region Check model type
+  // This check is intended only for verification, not for dispatch.
+
+  common::optional<
+    std::wstring
+  > model_type;
+
+  std::tie(
+    model_type,
+    error
+  ) = DeserializeWstring(
+    json["modelType"]
+  );
+
+  if (error.has_value()) {
+    error->path.segments.emplace_front(
+      common::make_unique<PropertySegment>(
+        L"modelType"
+      )
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  if (*model_type != L"ConceptDescription") {
+    std::wstring message = common::Concat(
+      L"Expected model type 'ConceptDescription', "
+      L"but got: ",
+      *model_type
+    );
+
+    error = common::make_optional<DeserializationError>(
+      message
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  // endregion Check model type
 
   return std::make_pair(
     common::make_optional<
@@ -23759,6 +24867,18 @@ std::pair<
     );
   }
 
+  if (!json.contains("modelType")) {
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      common::make_optional<DeserializationError>(
+        L"The required property modelType is missing"
+      )
+    );
+  }
+
   // endregion Check required properties
 
   // region Initialization
@@ -24374,6 +25494,58 @@ std::pair<
   }
 
   // endregion De-serialize levelType
+
+  // region Check model type
+  // This check is intended only for verification, not for dispatch.
+
+  common::optional<
+    std::wstring
+  > model_type;
+
+  std::tie(
+    model_type,
+    error
+  ) = DeserializeWstring(
+    json["modelType"]
+  );
+
+  if (error.has_value()) {
+    error->path.segments.emplace_front(
+      common::make_unique<PropertySegment>(
+        L"modelType"
+      )
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  if (*model_type != L"DataSpecificationIec61360") {
+    std::wstring message = common::Concat(
+      L"Expected model type 'DataSpecificationIec61360', "
+      L"but got: ",
+      *model_type
+    );
+
+    error = common::make_optional<DeserializationError>(
+      message
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<T> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  // endregion Check model type
 
   return std::make_pair(
     common::make_optional<

--- a/src/revm.cpp
+++ b/src/revm.cpp
@@ -286,7 +286,7 @@ std::string to_string(const InstructionSplit& instruction) {
 }
 
 InstructionKind InstructionEnd::kind() const {
-  return InstructionKind::End; 
+  return InstructionKind::End;
 }
 
 std::string to_string(const InstructionEnd&) {
@@ -467,7 +467,7 @@ class ThreadList {
 
   /**
    * Pop the thread from the back, returning its program counter.
-   * 
+   *
    * The order of the threads is not guaranteed.
    */
   size_t Pop() {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/AnnotatedRelationshipElement/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/AnnotatedRelationshipElement/invalidModelType.json
@@ -1,0 +1,32 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:another-company01:f390f801"
+              }
+            ],
+            "type": "ExternalReference"
+          },
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType",
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:an-example05:b7bf2725"
+              }
+            ],
+            "type": "ExternalReference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/AssetAdministrationShell/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/AssetAdministrationShell/invalidModelType.json
@@ -1,0 +1,12 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "NotApplicable",
+        "globalAssetId": "something_eea66fa1"
+      },
+      "id": "something_142922d6",
+      "modelType": "aCompletelyInvalidModelType"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/BasicEventElement/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/BasicEventElement/invalidModelType.json
@@ -1,0 +1,25 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "direction": "output",
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType",
+          "observed": {
+            "keys": [
+              {
+                "type": "Submodel",
+                "value": "urn:another-example11:3679ef43"
+              }
+            ],
+            "type": "ModelReference"
+          },
+          "state": "off"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Blob/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Blob/invalidModelType.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": "'VbrwFrYTU/fO7NnLxq   \t; \tMX.`10dB732`X5yRy=I56Ov9Us\t ;\t\t pRb~~hdw_C%2Zf=\"\"\t\t\t    \t\t\t \t \t\t \t  ; h=1t",
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Capability/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Capability/invalidModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/ConceptDescription/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/ConceptDescription/invalidModelType.json
@@ -1,0 +1,8 @@
+{
+  "conceptDescriptions": [
+    {
+      "id": "something_8ccad77f",
+      "modelType": "aCompletelyInvalidModelType"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/DataSpecificationIec61360/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/DataSpecificationIec61360/invalidModelType.json
@@ -1,0 +1,30 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "NotApplicable",
+        "globalAssetId": "something_eea66fa1"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecificationContent": {
+            "modelType": "aCompletelyInvalidModelType",
+            "preferredName": [
+              {
+                "language": "i-enochian",
+                "text": "something_84b0b440"
+              },
+              {
+                "language": "en-GB",
+                "text": "Something random in English 5b15c20d"
+              }
+            ],
+            "value": "something_13759f45"
+          }
+        }
+      ],
+      "id": "something_142922d6",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Entity/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Entity/invalidModelType.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "entityType": "CoManagedEntity",
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/File/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/File/invalidModelType.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": "'VbrwFrYTU/fO7NnLxq   \t; \tMX.`10dB732`X5yRy=I56Ov9Us\t ;\t\t pRb~~hdw_C%2Zf=\"\"\t\t\t    \t\t\t \t \t\t \t  ; h=1t",
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/MultiLanguageProperty/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/MultiLanguageProperty/invalidModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Operation/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Operation/invalidModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Property/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Property/invalidModelType.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType",
+          "valueType": "xs:decimal"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Range/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Range/invalidModelType.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType",
+          "valueType": "xs:decimal"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/ReferenceElement/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/ReferenceElement/invalidModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/RelationshipElement/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/RelationshipElement/invalidModelType.json
@@ -1,0 +1,32 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:another-company01:f390f801"
+              }
+            ],
+            "type": "ExternalReference"
+          },
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType",
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:an-example05:b7bf2725"
+              }
+            ],
+            "type": "ExternalReference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Submodel/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Submodel/invalidModelType.json
@@ -1,0 +1,8 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "aCompletelyInvalidModelType"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/SubmodelElementCollection/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/SubmodelElementCollection/invalidModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/SubmodelElementList/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/SubmodelElementList/invalidModelType.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType",
+          "typeValueListElement": "Entity"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AnnotatedRelationshipElement/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AnnotatedRelationshipElement/withoutModelType.json
@@ -1,0 +1,31 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:another-company01:f390f801"
+              }
+            ],
+            "type": "ExternalReference"
+          },
+          "idShort": "something3fdd3eb4",
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:an-example05:b7bf2725"
+              }
+            ],
+            "type": "ExternalReference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AssetAdministrationShell/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AssetAdministrationShell/withoutModelType.json
@@ -1,0 +1,11 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "NotApplicable",
+        "globalAssetId": "something_eea66fa1"
+      },
+      "id": "something_142922d6"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/BasicEventElement/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/BasicEventElement/withoutModelType.json
@@ -1,0 +1,24 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "direction": "output",
+          "idShort": "something3fdd3eb4",
+          "observed": {
+            "keys": [
+              {
+                "type": "Submodel",
+                "value": "urn:another-example11:3679ef43"
+              }
+            ],
+            "type": "ModelReference"
+          },
+          "state": "off"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Blob/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Blob/withoutModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": "'VbrwFrYTU/fO7NnLxq   \t; \tMX.`10dB732`X5yRy=I56Ov9Us\t ;\t\t pRb~~hdw_C%2Zf=\"\"\t\t\t    \t\t\t \t \t\t \t  ; h=1t",
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Capability/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Capability/withoutModelType.json
@@ -1,0 +1,13 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ConceptDescription/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ConceptDescription/withoutModelType.json
@@ -1,0 +1,7 @@
+{
+  "conceptDescriptions": [
+    {
+      "id": "something_8ccad77f"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/DataSpecificationIec61360/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/DataSpecificationIec61360/withoutModelType.json
@@ -1,0 +1,29 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "NotApplicable",
+        "globalAssetId": "something_eea66fa1"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "i-enochian",
+                "text": "something_84b0b440"
+              },
+              {
+                "language": "en-GB",
+                "text": "Something random in English 5b15c20d"
+              }
+            ],
+            "value": "something_13759f45"
+          }
+        }
+      ],
+      "id": "something_142922d6",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Entity/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Entity/withoutModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "entityType": "CoManagedEntity",
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/File/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/File/withoutModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": "'VbrwFrYTU/fO7NnLxq   \t; \tMX.`10dB732`X5yRy=I56Ov9Us\t ;\t\t pRb~~hdw_C%2Zf=\"\"\t\t\t    \t\t\t \t \t\t \t  ; h=1t",
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/MultiLanguageProperty/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/MultiLanguageProperty/withoutModelType.json
@@ -1,0 +1,13 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Operation/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Operation/withoutModelType.json
@@ -1,0 +1,13 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Property/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Property/withoutModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "valueType": "xs:decimal"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Range/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Range/withoutModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "valueType": "xs:decimal"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ReferenceElement/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ReferenceElement/withoutModelType.json
@@ -1,0 +1,13 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/RelationshipElement/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/RelationshipElement/withoutModelType.json
@@ -1,0 +1,31 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:another-company01:f390f801"
+              }
+            ],
+            "type": "ExternalReference"
+          },
+          "idShort": "something3fdd3eb4",
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:an-example05:b7bf2725"
+              }
+            ],
+            "type": "ExternalReference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Submodel/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Submodel/withoutModelType.json
@@ -1,0 +1,7 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementCollection/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementCollection/withoutModelType.json
@@ -1,0 +1,13 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementList/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementList/withoutModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "typeValueListElement": "Entity"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/AnnotatedRelationshipElement/invalidModelType.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/AnnotatedRelationshipElement/invalidModelType.json.error
@@ -1,0 +1,1 @@
+.submodels[0].submodelElements[0]: The dispatch to the JSON de-serialization of types::ISubmodelElement is not defined for model type: aCompletelyInvalidModelType

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/AssetAdministrationShell/invalidModelType.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/AssetAdministrationShell/invalidModelType.json.error
@@ -1,0 +1,1 @@
+.assetAdministrationShells[0]: Expected model type 'AssetAdministrationShell', but got: aCompletelyInvalidModelType

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/BasicEventElement/invalidModelType.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/BasicEventElement/invalidModelType.json.error
@@ -1,0 +1,1 @@
+.submodels[0].submodelElements[0]: The dispatch to the JSON de-serialization of types::ISubmodelElement is not defined for model type: aCompletelyInvalidModelType

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Blob/invalidModelType.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Blob/invalidModelType.json.error
@@ -1,0 +1,1 @@
+.submodels[0].submodelElements[0]: The dispatch to the JSON de-serialization of types::ISubmodelElement is not defined for model type: aCompletelyInvalidModelType

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Capability/invalidModelType.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Capability/invalidModelType.json.error
@@ -1,0 +1,1 @@
+.submodels[0].submodelElements[0]: The dispatch to the JSON de-serialization of types::ISubmodelElement is not defined for model type: aCompletelyInvalidModelType

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/ConceptDescription/invalidModelType.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/ConceptDescription/invalidModelType.json.error
@@ -1,0 +1,1 @@
+.conceptDescriptions[0]: Expected model type 'ConceptDescription', but got: aCompletelyInvalidModelType

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/DataSpecificationIec61360/invalidModelType.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/DataSpecificationIec61360/invalidModelType.json.error
@@ -1,0 +1,1 @@
+.assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent: The dispatch to the JSON de-serialization of types::IDataSpecificationContent is not defined for model type: aCompletelyInvalidModelType

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Entity/invalidModelType.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Entity/invalidModelType.json.error
@@ -1,0 +1,1 @@
+.submodels[0].submodelElements[0]: The dispatch to the JSON de-serialization of types::ISubmodelElement is not defined for model type: aCompletelyInvalidModelType

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/File/invalidModelType.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/File/invalidModelType.json.error
@@ -1,0 +1,1 @@
+.submodels[0].submodelElements[0]: The dispatch to the JSON de-serialization of types::ISubmodelElement is not defined for model type: aCompletelyInvalidModelType

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/MultiLanguageProperty/invalidModelType.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/MultiLanguageProperty/invalidModelType.json.error
@@ -1,0 +1,1 @@
+.submodels[0].submodelElements[0]: The dispatch to the JSON de-serialization of types::ISubmodelElement is not defined for model type: aCompletelyInvalidModelType

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Operation/invalidModelType.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Operation/invalidModelType.json.error
@@ -1,0 +1,1 @@
+.submodels[0].submodelElements[0]: The dispatch to the JSON de-serialization of types::ISubmodelElement is not defined for model type: aCompletelyInvalidModelType

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Property/invalidModelType.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Property/invalidModelType.json.error
@@ -1,0 +1,1 @@
+.submodels[0].submodelElements[0]: The dispatch to the JSON de-serialization of types::ISubmodelElement is not defined for model type: aCompletelyInvalidModelType

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Range/invalidModelType.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Range/invalidModelType.json.error
@@ -1,0 +1,1 @@
+.submodels[0].submodelElements[0]: The dispatch to the JSON de-serialization of types::ISubmodelElement is not defined for model type: aCompletelyInvalidModelType

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/ReferenceElement/invalidModelType.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/ReferenceElement/invalidModelType.json.error
@@ -1,0 +1,1 @@
+.submodels[0].submodelElements[0]: The dispatch to the JSON de-serialization of types::ISubmodelElement is not defined for model type: aCompletelyInvalidModelType

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/RelationshipElement/invalidModelType.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/RelationshipElement/invalidModelType.json.error
@@ -1,0 +1,1 @@
+.submodels[0].submodelElements[0]: The dispatch to the JSON de-serialization of types::ISubmodelElement is not defined for model type: aCompletelyInvalidModelType

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Submodel/invalidModelType.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Submodel/invalidModelType.json.error
@@ -1,0 +1,1 @@
+.submodels[0]: Expected model type 'Submodel', but got: aCompletelyInvalidModelType

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/SubmodelElementCollection/invalidModelType.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/SubmodelElementCollection/invalidModelType.json.error
@@ -1,0 +1,1 @@
+.submodels[0].submodelElements[0]: The dispatch to the JSON de-serialization of types::ISubmodelElement is not defined for model type: aCompletelyInvalidModelType

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/SubmodelElementList/invalidModelType.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/SubmodelElementList/invalidModelType.json.error
@@ -1,0 +1,1 @@
+.submodels[0].submodelElements[0]: The dispatch to the JSON de-serialization of types::ISubmodelElement is not defined for model type: aCompletelyInvalidModelType

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AnnotatedRelationshipElement/withoutModelType.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AnnotatedRelationshipElement/withoutModelType.json.error
@@ -1,0 +1,1 @@
+.submodels[0].submodelElements[0]: The required property modelType is missing

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AssetAdministrationShell/withoutModelType.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AssetAdministrationShell/withoutModelType.json.error
@@ -1,0 +1,1 @@
+.assetAdministrationShells[0]: The required property modelType is missing

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/BasicEventElement/withoutModelType.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/BasicEventElement/withoutModelType.json.error
@@ -1,0 +1,1 @@
+.submodels[0].submodelElements[0]: The required property modelType is missing

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Blob/withoutModelType.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Blob/withoutModelType.json.error
@@ -1,0 +1,1 @@
+.submodels[0].submodelElements[0]: The required property modelType is missing

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Capability/withoutModelType.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Capability/withoutModelType.json.error
@@ -1,0 +1,1 @@
+.submodels[0].submodelElements[0]: The required property modelType is missing

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ConceptDescription/withoutModelType.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ConceptDescription/withoutModelType.json.error
@@ -1,0 +1,1 @@
+.conceptDescriptions[0]: The required property modelType is missing

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/DataSpecificationIec61360/withoutModelType.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/DataSpecificationIec61360/withoutModelType.json.error
@@ -1,0 +1,1 @@
+.assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent: The required property modelType is missing

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Entity/withoutModelType.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Entity/withoutModelType.json.error
@@ -1,0 +1,1 @@
+.submodels[0].submodelElements[0]: The required property modelType is missing

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/File/withoutModelType.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/File/withoutModelType.json.error
@@ -1,0 +1,1 @@
+.submodels[0].submodelElements[0]: The required property modelType is missing

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/MultiLanguageProperty/withoutModelType.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/MultiLanguageProperty/withoutModelType.json.error
@@ -1,0 +1,1 @@
+.submodels[0].submodelElements[0]: The required property modelType is missing

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Operation/withoutModelType.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Operation/withoutModelType.json.error
@@ -1,0 +1,1 @@
+.submodels[0].submodelElements[0]: The required property modelType is missing

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Property/withoutModelType.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Property/withoutModelType.json.error
@@ -1,0 +1,1 @@
+.submodels[0].submodelElements[0]: The required property modelType is missing

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Range/withoutModelType.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Range/withoutModelType.json.error
@@ -1,0 +1,1 @@
+.submodels[0].submodelElements[0]: The required property modelType is missing

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ReferenceElement/withoutModelType.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ReferenceElement/withoutModelType.json.error
@@ -1,0 +1,1 @@
+.submodels[0].submodelElements[0]: The required property modelType is missing

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/RelationshipElement/withoutModelType.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/RelationshipElement/withoutModelType.json.error
@@ -1,0 +1,1 @@
+.submodels[0].submodelElements[0]: The required property modelType is missing

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Submodel/withoutModelType.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Submodel/withoutModelType.json.error
@@ -1,0 +1,1 @@
+.submodels[0]: The required property modelType is missing

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementCollection/withoutModelType.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementCollection/withoutModelType.json.error
@@ -1,0 +1,1 @@
+.submodels[0].submodelElements[0]: The required property modelType is missing

--- a/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementList/withoutModelType.json.error
+++ b/test_data/JsonizationError/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementList/withoutModelType.json.error
@@ -1,0 +1,1 @@
+.submodels[0].submodelElements[0]: The required property modelType is missing


### PR DESCRIPTION
We explicitly check during the JSON de-serialization that model types correspond to the expected model types. We need to be particularly careful with concrete classes without descendants with a mandatory ``modelType``, as they do not necessarily require a model type for de-serialization, but the specs mandate it for reasons of backward compatibility.

The code corresponds to [aas-core-codegen bd310fc2], and the test data corresponds to [aas-core3.0-testgen 9e523511c].

This is related to the issue [aas-core3.0-python #32], which discovered the problematic in the first place.

[aas-core-codegen bd310fc2]: https://github.com/aas-core-works/aas-core-codegen/commit/bd310fc2
[aas-core3.0-testgen 9e523511c]: https://github.com/aas-core-works/aas-core3.0-testgen/commit/9e523511c
[aas-core3.0-python #32]: https://github.com/aas-core-works/aas-core3.0-python/issues/32